### PR TITLE
Expose pages_per_task as config parameter in postgres_scan

### DIFF
--- a/postgres_scanner.cpp
+++ b/postgres_scanner.cpp
@@ -229,6 +229,7 @@ static unique_ptr<FunctionData> PostgresBind(ClientContext &context, TableFuncti
 	bind_data->dsn = input.inputs[0].GetValue<string>();
 	bind_data->schema_name = input.inputs[1].GetValue<string>();
 	bind_data->table_name = input.inputs[2].GetValue<string>();
+	bind_data->pages_per_task = input.inputs[3].GetValue<int>();
 
 	bind_data->conn = PGConnect(bind_data->dsn);
 
@@ -1106,7 +1107,7 @@ ORDER BY relname;
 class PostgresScanFunction : public TableFunction {
 public:
 	PostgresScanFunction()
-	    : TableFunction("postgres_scan", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	    : TableFunction("postgres_scan", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::UBIGINT},
 	                    PostgresScan, PostgresBind, PostgresInitGlobalState, PostgresInitLocalState) {
 		to_string = PostgresScanToString;
 		projection_pushdown = true;
@@ -1116,7 +1117,7 @@ public:
 class PostgresScanFunctionFilterPushdown : public TableFunction {
 public:
 	PostgresScanFunctionFilterPushdown()
-	    : TableFunction("postgres_scan_pushdown", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR},
+	    : TableFunction("postgres_scan_pushdown", {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::UBIGINT} ,
 	                    PostgresScan, PostgresBind, PostgresInitGlobalState, PostgresInitLocalState) {
 		to_string = PostgresScanToString;
 		projection_pushdown = true;


### PR DESCRIPTION
The Postgres scanner works really well, but certain tables, in particular, demonstrate long query times, taking about an hour to load the full table. Some tables of similar size, on the other hand, work much faster. Therefore, we started investigating to find the cause of the slow ingestion from Postgres. It turned out that this was caused by a parameter that controls the number of rows per page returned in parallel during data downloading. After adjusting the 'pages_per_task' parameter from the default value of 1000 to 1,000,000, the average time reduced to 467.30 seconds from the initial one hour. That's why I believe that 'pages_per_task' should be exposed as a config parameter, and that's my proposition for the issue. (Tbh, I think it would be better if the parameter were optional, but I don't have any idea how to manage this without extra modules or bumping the C++ version to C++17)