### PR TITLE
Fix #113: Add missing std::move for old GCC

### DIFF
--- a/src/postgres_scanner.cpp
+++ b/src/postgres_scanner.cpp
@@ -202,7 +202,7 @@ static unique_ptr<GlobalTableFunctionState> PostgresInitGlobalState(ClientContex
 		result->collection = std::move(materialized);
 		result->collection->InitializeScan(result->scan_state);
 	}
-	return result;
+	return std::move(result);
 }
 
 static bool PostgresParallelStateNext(ClientContext &context, const FunctionData *bind_data_p,
@@ -231,7 +231,7 @@ static unique_ptr<LocalTableFunctionState> GetLocalState(ClientContext &context,
 
 	auto local_state = make_uniq<PostgresLocalState>();
 	if (gstate.collection) {
-		return local_state;
+		return std::move(local_state);
 	}
 	local_state->column_ids = input.column_ids;
 


### PR DESCRIPTION
Fixes #113 