### PR TITLE
Add support for batch indexes to the Postgres scanner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,11 +115,10 @@ add_subdirectory(src)
 prepend(LIBPG_SOURCES_FULLPATH ${CMAKE_CURRENT_SOURCE_DIR} ${LIBPG_SOURCES})
 
 if(EXISTS "postgres")
+
 else()
-  execute_process(
-    COMMAND sh pgconfigure ${LIBPG_SOURCES_FULLPATH}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  )
+  execute_process(COMMAND sh pgconfigure ${LIBPG_SOURCES_FULLPATH}
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 add_custom_command(
   OUTPUT ${LIBPG_SOURCES_FULLPATH}

--- a/src/include/postgres_version.hpp
+++ b/src/include/postgres_version.hpp
@@ -15,7 +15,8 @@ namespace duckdb {
 struct PostgresVersion {
 	PostgresVersion() {
 	}
-	PostgresVersion(idx_t major_v, idx_t minor_v, idx_t patch_v = 0) : major_v(major_v), minor_v(minor_v), patch_v(patch_v) {
+	PostgresVersion(idx_t major_v, idx_t minor_v, idx_t patch_v = 0)
+	    : major_v(major_v), minor_v(minor_v), patch_v(patch_v) {
 	}
 
 	idx_t major_v = 0;

--- a/test/sql/storage/attach_insert_from_scan_large.test
+++ b/test/sql/storage/attach_insert_from_scan_large.test
@@ -35,3 +35,18 @@ query I
 SELECT COUNT(*) FROM s.tbl
 ----
 400000
+
+query I
+CREATE TABLE duck_tbl AS FROM s.tbl
+----
+400000
+
+query II
+SELECT COUNT(*), SUM(i) FROM duck_tbl
+----
+400000	19999800000
+
+query II
+SELECT COUNT(*), SUM(i) FROM s.tbl
+----
+400000	19999800000


### PR DESCRIPTION
Fixes #118

Makes it so that scans are run in parallel when running a `CREATE TABLE` also without setting `preserve_insertion_order`