### PR TITLE
Detect that we are connected with Aurora, and avoid running snapshot code with Aurora in general

### DIFF
--- a/src/include/postgres_version.hpp
+++ b/src/include/postgres_version.hpp
@@ -12,6 +12,8 @@
 
 namespace duckdb {
 
+enum class PostgresInstanceType { POSTGRES, AURORA };
+
 struct PostgresVersion {
 	PostgresVersion() {
 	}
@@ -22,6 +24,7 @@ struct PostgresVersion {
 	idx_t major_v = 0;
 	idx_t minor_v = 0;
 	idx_t patch_v = 0;
+	PostgresInstanceType type_v = PostgresInstanceType::POSTGRES;
 
 	inline bool operator<(const PostgresVersion &rhs) const {
 		if (major_v < rhs.major_v) {

--- a/src/postgres_connection.cpp
+++ b/src/postgres_connection.cpp
@@ -80,8 +80,11 @@ void PostgresConnection::Execute(const string &query) {
 }
 
 PostgresVersion PostgresConnection::GetPostgresVersion() {
-	auto result = Query("SHOW server_version;");
+	auto result = Query("SELECT CURRENT_SETTING('server_version'), (SELECT COUNT(*) FROM pg_settings WHERE name LIKE 'rds%')");
 	auto version = PostgresUtils::ExtractPostgresVersion(result->GetString(0, 0));
+	if (result->GetInt64(0, 1) > 0) {
+		version.type_v = PostgresInstanceType::AURORA;
+	}
 	return version;
 }
 


### PR DESCRIPTION
Follow-up fix to #134, should solve more issues around AWS Aurora