### PR TITLE
Keep connections cached, and reduce round-trips

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       duckdb_version: v0.9.2
       extension_name: postgres_scanner
+      vcpkg_commit: 9edb1b8e590cc086563301d735cae4b6e732d2d2 # TODO: remove pinned vcpkg commit when updating duckdb version
 
   duckdb-stable-deploy:
     name: Deploy extension binaries

--- a/src/include/postgres_connection.hpp
+++ b/src/include/postgres_connection.hpp
@@ -56,6 +56,9 @@ public:
 	unique_ptr<PostgresResult> TryQuery(const string &query, optional_ptr<string> error_message = nullptr);
 	unique_ptr<PostgresResult> Query(const string &query);
 
+	//! Submits a set of queries to be executed in the connection.
+	vector<unique_ptr<PostgresResult>> ExecuteQueries(const string &queries);
+
 	PostgresVersion GetPostgresVersion();
 
 	vector<IndexInfo> GetIndexInfo(const string &table_name);

--- a/src/include/postgres_scanner.hpp
+++ b/src/include/postgres_scanner.hpp
@@ -41,13 +41,13 @@ struct PostgresBindData : public FunctionData {
 	idx_t max_threads = 1;
 
 public:
-	PostgresConnection &GetConnection(ClientContext &context);
-	PostgresConnection &GetConnectionRaw(ClientContext &context);
 	void SetTablePages(idx_t approx_num_pages);
 
+	PostgresConnection &GetConnection();
 	void SetConnection(PostgresConnection connection);
 	void SetConnection(shared_ptr<OwnedPostgresConnection> connection);
 	void SetCatalog(PostgresCatalog &catalog);
+
 	bool TryOpenNewConnection(ClientContext &context, PostgresLocalState &lstate, PostgresGlobalState &gstate);
 
 	unique_ptr<FunctionData> Copy() const override {
@@ -58,8 +58,8 @@ public:
 	}
 
 private:
+	PostgresConnection connection;
 	optional_ptr<PostgresCatalog> pg_catalog;
-	PostgresConnection pg_connection;
 };
 
 class PostgresAttachFunction : public TableFunction {

--- a/src/include/postgres_scanner.hpp
+++ b/src/include/postgres_scanner.hpp
@@ -14,6 +14,7 @@
 #include "storage/postgres_connection_pool.hpp"
 
 namespace duckdb {
+class PostgresCatalog;
 class PostgresTransaction;
 
 struct PostgresBindData : public FunctionData {
@@ -37,11 +38,15 @@ struct PostgresBindData : public FunctionData {
 	bool emit_ctid = false;
 	idx_t max_threads = 1;
 
-	PostgresConnection connection;
 	PostgresConnectionReservation connection_reservation;
 
 public:
+	PostgresConnection &GetConnection(ClientContext &context);
 	void SetTablePages(idx_t approx_num_pages);
+
+	void SetConnection(PostgresConnection connection);
+	void SetConnection(shared_ptr<OwnedPostgresConnection> connection);
+	void SetCatalog(PostgresCatalog &catalog);
 
 	unique_ptr<FunctionData> Copy() const override {
 		throw NotImplementedException("");
@@ -49,6 +54,10 @@ public:
 	bool Equals(const FunctionData &other_p) const override {
 		return false;
 	}
+
+private:
+	optional_ptr<PostgresCatalog> pg_catalog;
+	PostgresConnection pg_connection;
 };
 
 class PostgresAttachFunction : public TableFunction {

--- a/src/include/storage/postgres_catalog.hpp
+++ b/src/include/storage/postgres_catalog.hpp
@@ -15,12 +15,12 @@
 #include "storage/postgres_connection_pool.hpp"
 
 namespace duckdb {
+class PostgresCatalog;
 class PostgresSchemaEntry;
 
 class PostgresCatalog : public Catalog {
 public:
-	explicit PostgresCatalog(PostgresVersion version, AttachedDatabase &db_p, const string &path,
-	                         AccessMode access_mode);
+	explicit PostgresCatalog(AttachedDatabase &db_p, const string &path, AccessMode access_mode);
 	~PostgresCatalog();
 
 	string path;

--- a/src/include/storage/postgres_catalog_set.hpp
+++ b/src/include/storage/postgres_catalog_set.hpp
@@ -29,13 +29,6 @@ public:
 
 protected:
 	virtual void LoadEntries(ClientContext &context) = 0;
-	void SetLoaded() {
-		is_loaded = true;
-	}
-	bool IsLoaded() {
-		return is_loaded;
-	}
-
 protected:
 	Catalog &catalog;
 
@@ -47,10 +40,14 @@ private:
 };
 
 struct PostgresResultSlice {
-	PostgresResultSlice(PostgresResult &result, idx_t start, idx_t end) : result(result), start(start), end(end) {
+	PostgresResultSlice(shared_ptr<PostgresResult> result_p, idx_t start, idx_t end) : result(std::move(result_p)), start(start), end(end) {
 	}
 
-	PostgresResult &result;
+	PostgresResult &GetResult() {
+		return *result;
+	}
+
+	shared_ptr<PostgresResult> result;
 	idx_t start;
 	idx_t end;
 };

--- a/src/include/storage/postgres_catalog_set.hpp
+++ b/src/include/storage/postgres_catalog_set.hpp
@@ -29,6 +29,7 @@ public:
 
 protected:
 	virtual void LoadEntries(ClientContext &context) = 0;
+
 protected:
 	Catalog &catalog;
 
@@ -40,7 +41,8 @@ private:
 };
 
 struct PostgresResultSlice {
-	PostgresResultSlice(shared_ptr<PostgresResult> result_p, idx_t start, idx_t end) : result(std::move(result_p)), start(start), end(end) {
+	PostgresResultSlice(shared_ptr<PostgresResult> result_p, idx_t start, idx_t end)
+	    : result(std::move(result_p)), start(start), end(end) {
 	}
 
 	PostgresResult &GetResult() {

--- a/src/include/storage/postgres_catalog_set.hpp
+++ b/src/include/storage/postgres_catalog_set.hpp
@@ -14,6 +14,7 @@
 
 namespace duckdb {
 struct DropInfo;
+class PostgresResult;
 class PostgresTransaction;
 
 class PostgresCatalogSet {
@@ -28,6 +29,12 @@ public:
 
 protected:
 	virtual void LoadEntries(ClientContext &context) = 0;
+	void SetLoaded() {
+		is_loaded = true;
+	}
+	bool IsLoaded() {
+		return is_loaded;
+	}
 
 protected:
 	Catalog &catalog;
@@ -37,6 +44,15 @@ private:
 	unordered_map<string, unique_ptr<CatalogEntry>> entries;
 	case_insensitive_map_t<string> entry_map;
 	bool is_loaded;
+};
+
+struct PostgresResultSlice {
+	PostgresResultSlice(PostgresResult &result, idx_t start, idx_t end) : result(result), start(start), end(end) {
+	}
+
+	PostgresResult &result;
+	idx_t start;
+	idx_t end;
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_index_set.hpp
+++ b/src/include/storage/postgres_index_set.hpp
@@ -18,6 +18,13 @@ class PostgresIndexSet : public PostgresCatalogSet {
 public:
 	PostgresIndexSet(PostgresSchemaEntry &schema);
 
+public:
+	void Initialize(PostgresResultSlice &indexes);
+
+	static string GetInitializeQuery();
+
+	optional_ptr<CatalogEntry> CreateIndex(ClientContext &context, CreateIndexInfo &info, TableCatalogEntry &table);
+
 protected:
 	void LoadEntries(ClientContext &context) override;
 

--- a/src/include/storage/postgres_index_set.hpp
+++ b/src/include/storage/postgres_index_set.hpp
@@ -16,11 +16,9 @@ class PostgresSchemaEntry;
 
 class PostgresIndexSet : public PostgresCatalogSet {
 public:
-	PostgresIndexSet(PostgresSchemaEntry &schema);
+	PostgresIndexSet(PostgresSchemaEntry &schema, unique_ptr<PostgresResultSlice> index_result = nullptr);
 
 public:
-	void Initialize(PostgresResultSlice &indexes);
-
 	static string GetInitializeQuery();
 
 	optional_ptr<CatalogEntry> CreateIndex(ClientContext &context, CreateIndexInfo &info, TableCatalogEntry &table);
@@ -30,6 +28,7 @@ protected:
 
 protected:
 	PostgresSchemaEntry &schema;
+	unique_ptr<PostgresResultSlice> index_result;
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_schema_entry.hpp
+++ b/src/include/storage/postgres_schema_entry.hpp
@@ -19,11 +19,9 @@ class PostgresTransaction;
 class PostgresSchemaEntry : public SchemaCatalogEntry {
 public:
 	PostgresSchemaEntry(Catalog &catalog, string name);
-	PostgresSchemaEntry(Catalog &catalog, string name,
-						unique_ptr<PostgresResultSlice> tables,
-	                    unique_ptr<PostgresResultSlice> enums,
-						unique_ptr<PostgresResultSlice> composite_types,
-						unique_ptr<PostgresResultSlice> indexes);
+	PostgresSchemaEntry(Catalog &catalog, string name, unique_ptr<PostgresResultSlice> tables,
+	                    unique_ptr<PostgresResultSlice> enums, unique_ptr<PostgresResultSlice> composite_types,
+	                    unique_ptr<PostgresResultSlice> indexes);
 
 public:
 	optional_ptr<CatalogEntry> CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) override;

--- a/src/include/storage/postgres_schema_entry.hpp
+++ b/src/include/storage/postgres_schema_entry.hpp
@@ -19,8 +19,11 @@ class PostgresTransaction;
 class PostgresSchemaEntry : public SchemaCatalogEntry {
 public:
 	PostgresSchemaEntry(Catalog &catalog, string name);
-	PostgresSchemaEntry(PostgresTransaction &transaction, Catalog &catalog, string name, PostgresResultSlice &tables,
-	                    PostgresResultSlice &enums, PostgresResultSlice &composite_types, PostgresResultSlice &indexes);
+	PostgresSchemaEntry(Catalog &catalog, string name,
+						unique_ptr<PostgresResultSlice> tables,
+	                    unique_ptr<PostgresResultSlice> enums,
+						unique_ptr<PostgresResultSlice> composite_types,
+						unique_ptr<PostgresResultSlice> indexes);
 
 public:
 	optional_ptr<CatalogEntry> CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) override;

--- a/src/include/storage/postgres_schema_entry.hpp
+++ b/src/include/storage/postgres_schema_entry.hpp
@@ -19,6 +19,8 @@ class PostgresTransaction;
 class PostgresSchemaEntry : public SchemaCatalogEntry {
 public:
 	PostgresSchemaEntry(Catalog &catalog, string name);
+	PostgresSchemaEntry(PostgresTransaction &transaction, Catalog &catalog, string name, PostgresResultSlice &tables,
+	                    PostgresResultSlice &enums, PostgresResultSlice &composite_types, PostgresResultSlice &indexes);
 
 public:
 	optional_ptr<CatalogEntry> CreateTable(CatalogTransaction transaction, BoundCreateTableInfo &info) override;

--- a/src/include/storage/postgres_schema_set.hpp
+++ b/src/include/storage/postgres_schema_set.hpp
@@ -21,6 +21,8 @@ public:
 public:
 	optional_ptr<CatalogEntry> CreateSchema(ClientContext &context, CreateSchemaInfo &info);
 
+	static string GetInitializeQuery();
+
 protected:
 	void LoadEntries(ClientContext &context) override;
 };

--- a/src/include/storage/postgres_table_set.hpp
+++ b/src/include/storage/postgres_table_set.hpp
@@ -19,10 +19,10 @@ class PostgresSchemaEntry;
 
 class PostgresTableSet : public PostgresCatalogSet {
 public:
-	explicit PostgresTableSet(PostgresSchemaEntry &schema);
+	explicit PostgresTableSet(PostgresSchemaEntry &schema, unique_ptr<PostgresResultSlice> tables = nullptr);
+
 
 public:
-	void Initialize(PostgresTransaction &transaction, PostgresResultSlice &tables);
 	optional_ptr<CatalogEntry> CreateTable(ClientContext &context, BoundCreateTableInfo &info);
 
 	static unique_ptr<PostgresTableInfo> GetTableInfo(PostgresTransaction &transaction, PostgresSchemaEntry &schema,
@@ -51,6 +51,7 @@ protected:
 
 protected:
 	PostgresSchemaEntry &schema;
+	unique_ptr<PostgresResultSlice> table_result;
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_table_set.hpp
+++ b/src/include/storage/postgres_table_set.hpp
@@ -21,7 +21,6 @@ class PostgresTableSet : public PostgresCatalogSet {
 public:
 	explicit PostgresTableSet(PostgresSchemaEntry &schema, unique_ptr<PostgresResultSlice> tables = nullptr);
 
-
 public:
 	optional_ptr<CatalogEntry> CreateTable(ClientContext &context, BoundCreateTableInfo &info);
 

--- a/src/include/storage/postgres_table_set.hpp
+++ b/src/include/storage/postgres_table_set.hpp
@@ -22,6 +22,7 @@ public:
 	explicit PostgresTableSet(PostgresSchemaEntry &schema);
 
 public:
+	void Initialize(PostgresTransaction &transaction, PostgresResultSlice &tables);
 	optional_ptr<CatalogEntry> CreateTable(ClientContext &context, BoundCreateTableInfo &info);
 
 	static unique_ptr<PostgresTableInfo> GetTableInfo(PostgresTransaction &transaction, PostgresSchemaEntry &schema,
@@ -31,6 +32,8 @@ public:
 	optional_ptr<CatalogEntry> RefreshTable(ClientContext &context, const string &table_name);
 
 	void AlterTable(ClientContext &context, AlterTableInfo &info);
+
+	static string GetInitializeQuery();
 
 protected:
 	void LoadEntries(ClientContext &context) override;
@@ -42,6 +45,9 @@ protected:
 
 	static void AddColumn(optional_ptr<PostgresTransaction> transaction, optional_ptr<PostgresSchemaEntry> schema,
 	                      PostgresResult &result, idx_t row, PostgresTableInfo &table_info, idx_t column_offset = 0);
+
+	void CreateEntries(PostgresTransaction &transaction, PostgresResult &result, idx_t start, idx_t end,
+	                   idx_t col_offset);
 
 protected:
 	PostgresSchemaEntry &schema;

--- a/src/include/storage/postgres_transaction.hpp
+++ b/src/include/storage/postgres_transaction.hpp
@@ -31,6 +31,8 @@ public:
 	string GetDSN() {
 		return connection.GetDSN();
 	}
+	//! Retrieves the connection **without** starting a transaction if none is active
+	PostgresConnection &GetConnectionRaw();
 	unique_ptr<PostgresResult> Query(const string &query);
 	vector<unique_ptr<PostgresResult>> ExecuteQueries(const string &queries);
 	static PostgresTransaction &Get(ClientContext &context, Catalog &catalog);

--- a/src/include/storage/postgres_transaction.hpp
+++ b/src/include/storage/postgres_transaction.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/transaction/transaction.hpp"
 #include "postgres_connection.hpp"
+#include "storage/postgres_connection_pool.hpp"
 
 namespace duckdb {
 class PostgresCatalog;
@@ -28,9 +29,7 @@ public:
 	void Rollback();
 
 	PostgresConnection &GetConnection();
-	string GetDSN() {
-		return connection.GetDSN();
-	}
+	string GetDSN();
 	//! Retrieves the connection **without** starting a transaction if none is active
 	PostgresConnection &GetConnectionRaw();
 	unique_ptr<PostgresResult> Query(const string &query);
@@ -38,7 +37,7 @@ public:
 	static PostgresTransaction &Get(ClientContext &context, Catalog &catalog);
 
 private:
-	PostgresConnection connection;
+	PostgresPoolConnection connection;
 	PostgresTransactionState transaction_state;
 	AccessMode access_mode;
 };

--- a/src/include/storage/postgres_transaction.hpp
+++ b/src/include/storage/postgres_transaction.hpp
@@ -30,8 +30,6 @@ public:
 
 	PostgresConnection &GetConnection();
 	string GetDSN();
-	//! Retrieves the connection **without** starting a transaction if none is active
-	PostgresConnection &GetConnectionRaw();
 	unique_ptr<PostgresResult> Query(const string &query);
 	vector<unique_ptr<PostgresResult>> ExecuteQueries(const string &queries);
 	static PostgresTransaction &Get(ClientContext &context, Catalog &catalog);
@@ -40,6 +38,10 @@ private:
 	PostgresPoolConnection connection;
 	PostgresTransactionState transaction_state;
 	AccessMode access_mode;
+
+private:
+	//! Retrieves the connection **without** starting a transaction if none is active
+	PostgresConnection &GetConnectionRaw();
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_transaction.hpp
+++ b/src/include/storage/postgres_transaction.hpp
@@ -28,6 +28,9 @@ public:
 	void Rollback();
 
 	PostgresConnection &GetConnection();
+	string GetDSN() {
+		return connection.GetDSN();
+	}
 	unique_ptr<PostgresResult> Query(const string &query);
 	static PostgresTransaction &Get(ClientContext &context, Catalog &catalog);
 

--- a/src/include/storage/postgres_transaction.hpp
+++ b/src/include/storage/postgres_transaction.hpp
@@ -32,6 +32,7 @@ public:
 		return connection.GetDSN();
 	}
 	unique_ptr<PostgresResult> Query(const string &query);
+	vector<unique_ptr<PostgresResult>> ExecuteQueries(const string &queries);
 	static PostgresTransaction &Get(ClientContext &context, Catalog &catalog);
 
 private:

--- a/src/include/storage/postgres_type_set.hpp
+++ b/src/include/storage/postgres_type_set.hpp
@@ -24,14 +24,20 @@ public:
 public:
 	optional_ptr<CatalogEntry> CreateType(ClientContext &context, CreateTypeInfo &info);
 
+	void Initialize(PostgresTransaction &transaction, PostgresResultSlice &enums, PostgresResultSlice &composite_types);
+
+	static string GetInitializeEnumsQuery();
+	static string GetInitializeCompositesQuery();
+
 protected:
 	void LoadEntries(ClientContext &context) override;
 
-	void LoadEnumTypes(PostgresTransaction &transaction, vector<PGTypeInfo> &enum_info);
 	void CreateEnum(PostgresResult &result, idx_t start_row, idx_t end_row);
-	void LoadCompositeTypes(PostgresTransaction &transaction, vector<PGTypeInfo> &composite_info);
-	void CreateCompositeType(PostgresTransaction &transaction, PostgresResult &result, idx_t start_row, idx_t end_row,
-	                         unordered_map<idx_t, string> &name_map);
+	void CreateCompositeType(PostgresTransaction &transaction, PostgresResult &result, idx_t start_row, idx_t end_row);
+
+	void InitializeEnums(PostgresResultSlice &enums);
+	void InitializeCompositeTypes(PostgresTransaction &transaction, PostgresResultSlice &composite_types);
+
 
 protected:
 	PostgresSchemaEntry &schema;

--- a/src/include/storage/postgres_type_set.hpp
+++ b/src/include/storage/postgres_type_set.hpp
@@ -19,9 +19,8 @@ struct PGTypeInfo;
 
 class PostgresTypeSet : public PostgresCatalogSet {
 public:
-	explicit PostgresTypeSet(PostgresSchemaEntry &schema,
-							 unique_ptr<PostgresResultSlice> enum_result = nullptr,
-							 unique_ptr<PostgresResultSlice> composite_type_result = nullptr);
+	explicit PostgresTypeSet(PostgresSchemaEntry &schema, unique_ptr<PostgresResultSlice> enum_result = nullptr,
+	                         unique_ptr<PostgresResultSlice> composite_type_result = nullptr);
 
 public:
 	optional_ptr<CatalogEntry> CreateType(ClientContext &context, CreateTypeInfo &info);

--- a/src/include/storage/postgres_type_set.hpp
+++ b/src/include/storage/postgres_type_set.hpp
@@ -19,12 +19,12 @@ struct PGTypeInfo;
 
 class PostgresTypeSet : public PostgresCatalogSet {
 public:
-	explicit PostgresTypeSet(PostgresSchemaEntry &schema);
+	explicit PostgresTypeSet(PostgresSchemaEntry &schema,
+							 unique_ptr<PostgresResultSlice> enum_result = nullptr,
+							 unique_ptr<PostgresResultSlice> composite_type_result = nullptr);
 
 public:
 	optional_ptr<CatalogEntry> CreateType(ClientContext &context, CreateTypeInfo &info);
-
-	void Initialize(PostgresTransaction &transaction, PostgresResultSlice &enums, PostgresResultSlice &composite_types);
 
 	static string GetInitializeEnumsQuery();
 	static string GetInitializeCompositesQuery();
@@ -38,9 +38,10 @@ protected:
 	void InitializeEnums(PostgresResultSlice &enums);
 	void InitializeCompositeTypes(PostgresTransaction &transaction, PostgresResultSlice &composite_types);
 
-
 protected:
 	PostgresSchemaEntry &schema;
+	unique_ptr<PostgresResultSlice> enum_result;
+	unique_ptr<PostgresResultSlice> composite_type_result;
 };
 
 } // namespace duckdb

--- a/src/postgres_query.cpp
+++ b/src/postgres_query.cpp
@@ -64,7 +64,7 @@ static unique_ptr<FunctionData> PGQueryBind(ClientContext &context, TableFunctio
 
 	// set up the bind data
 	result->dsn = con.GetDSN();
-	result->connection = PostgresConnection(con.GetConnection());
+	result->SetConnection(con.GetConnection());
 	result->types = return_types;
 	result->names = names;
 	result->read_only = false;

--- a/src/postgres_scanner.cpp
+++ b/src/postgres_scanner.cpp
@@ -106,7 +106,7 @@ void PostgresBindData::SetTablePages(idx_t approx_num_pages) {
 
 PostgresConnection &PostgresBindData::GetConnection(ClientContext &context) {
 	if (pg_catalog) {
-		return PostgresTransaction::Get(context, *pg_catalog).GetConnection();
+		return PostgresTransaction::Get(context, *pg_catalog).GetConnectionRaw();
 	}
 	return pg_connection;
 }

--- a/src/postgres_storage.cpp
+++ b/src/postgres_storage.cpp
@@ -9,9 +9,7 @@ namespace duckdb {
 
 static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, AttachedDatabase &db, const string &name,
                                         AttachInfo &info, AccessMode access_mode) {
-	auto connection = PostgresConnection::Open(info.path);
-	auto version = connection.GetPostgresVersion();
-	return make_uniq<PostgresCatalog>(version, db, info.path, access_mode);
+	return make_uniq<PostgresCatalog>(db, info.path, access_mode);
 }
 
 static unique_ptr<TransactionManager> PostgresCreateTransactionManager(StorageExtensionInfo *storage_info,

--- a/src/storage/postgres_index_set.cpp
+++ b/src/storage/postgres_index_set.cpp
@@ -3,26 +3,22 @@
 #include "storage/postgres_transaction.hpp"
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
 #include "storage/postgres_index_entry.hpp"
+#include "duckdb/parser/parsed_expression_iterator.hpp"
 
 namespace duckdb {
 
 PostgresIndexSet::PostgresIndexSet(PostgresSchemaEntry &schema) :
     PostgresCatalogSet(schema.ParentCatalog()), schema(schema) {}
 
-void PostgresIndexSet::LoadEntries(ClientContext &context) {
-	auto query = StringUtil::Replace(R"(
-SELECT tablename, indexname
-FROM pg_indexes
-WHERE schemaname=${SCHEMA_NAME}
-)", "${SCHEMA_NAME}", KeywordHelper::WriteQuoted(schema.name));
 
-	auto &transaction = PostgresTransaction::Get(context, catalog);
-	auto result = transaction.Query(query);
-	auto rows = result->Count();
-
-	for(idx_t row = 0; row < rows; row++) {
-		auto table_name = result->GetString(row, 0);
-		auto index_name = result->GetString(row, 1);
+void PostgresIndexSet::Initialize(PostgresResultSlice &index_slice) {
+	if (IsLoaded()) {
+		throw InternalException("PostgresIndexSet::Initialize cannot be called on a loaded index set");
+	}
+	auto &result = index_slice.result;
+	for(idx_t row = index_slice.start; row < index_slice.end; row++) {
+		auto table_name = result.GetString(row, 1);
+		auto index_name = result.GetString(row, 2);
 		CreateIndexInfo info;
 		info.schema = schema.name;
 		info.table = table_name;
@@ -30,6 +26,60 @@ WHERE schemaname=${SCHEMA_NAME}
 		auto index_entry = make_uniq<PostgresIndexEntry>(catalog, schema, info, table_name);
 		CreateEntry(std::move(index_entry));
 	}
+	SetLoaded();
+}
+
+string PostgresIndexSet::GetInitializeQuery() {
+	return R"(
+SELECT pg_namespace.oid, tablename, indexname
+FROM pg_indexes
+JOIN pg_namespace ON (schemaname=nspname)
+ORDER BY pg_namespace.oid;
+)";
+}
+
+void PostgresIndexSet::LoadEntries(ClientContext &context) {
+	throw InternalException("PostgresIndexSet::LoadEntries not defined");
+}
+
+void PGUnqualifyColumnReferences(ParsedExpression &expr) {
+	if (expr.type == ExpressionType::COLUMN_REF) {
+		auto &colref = expr.Cast<ColumnRefExpression>();
+		auto name = std::move(colref.column_names.back());
+		colref.column_names = {std::move(name)};
+		return;
+	}
+	ParsedExpressionIterator::EnumerateChildren(expr, PGUnqualifyColumnReferences);
+}
+
+string PGGetCreateIndexSQL(CreateIndexInfo &info, TableCatalogEntry &tbl) {
+	string sql;
+	sql = "CREATE";
+	if (info.constraint_type == IndexConstraintType::UNIQUE) {
+		sql += " UNIQUE";
+	}
+	sql += " INDEX ";
+	sql += KeywordHelper::WriteOptionallyQuoted(info.index_name);
+	sql += " ON ";
+	sql += KeywordHelper::WriteOptionallyQuoted(tbl.name);
+	sql += "(";
+	for (idx_t i = 0; i < info.parsed_expressions.size(); i++) {
+		if (i > 0) {
+			sql += ", ";
+		}
+		PGUnqualifyColumnReferences(*info.parsed_expressions[i]);
+		sql += info.parsed_expressions[i]->ToString();
+	}
+	sql += ")";
+	return sql;
+}
+
+optional_ptr<CatalogEntry> PostgresIndexSet::CreateIndex(ClientContext &context, CreateIndexInfo &info,
+                                                          TableCatalogEntry &table) {
+	auto &postgres_transaction = PostgresTransaction::Get(context, table.catalog);
+	postgres_transaction.Query(PGGetCreateIndexSQL(info, table));
+	auto index_entry = make_uniq<PostgresIndexEntry>(schema.ParentCatalog(), schema, info, table.name);
+	return CreateEntry(std::move(index_entry));
 }
 
 }

--- a/src/storage/postgres_schema_entry.cpp
+++ b/src/storage/postgres_schema_entry.cpp
@@ -21,6 +21,7 @@ PostgresSchemaEntry::PostgresSchemaEntry(Catalog &catalog, string name) :
 PostgresSchemaEntry::PostgresSchemaEntry(PostgresTransaction &transaction, Catalog &catalog, string name, PostgresResultSlice &table_slice, PostgresResultSlice &enums, PostgresResultSlice &composite_types, PostgresResultSlice &index_slice) :
     SchemaCatalogEntry(catalog, std::move(name), true), tables(*this), indexes(*this),
 	types(*this) {
+	types.Initialize(transaction, enums, composite_types);
 	tables.Initialize(transaction, table_slice);
 	indexes.Initialize(index_slice);
 }

--- a/src/storage/postgres_schema_entry.cpp
+++ b/src/storage/postgres_schema_entry.cpp
@@ -18,12 +18,15 @@ PostgresSchemaEntry::PostgresSchemaEntry(Catalog &catalog, string name) :
 	types(*this) {
 }
 
-PostgresSchemaEntry::PostgresSchemaEntry(PostgresTransaction &transaction, Catalog &catalog, string name, PostgresResultSlice &table_slice, PostgresResultSlice &enums, PostgresResultSlice &composite_types, PostgresResultSlice &index_slice) :
-    SchemaCatalogEntry(catalog, std::move(name), true), tables(*this), indexes(*this),
-	types(*this) {
-	types.Initialize(transaction, enums, composite_types);
-	tables.Initialize(transaction, table_slice);
-	indexes.Initialize(index_slice);
+PostgresSchemaEntry::PostgresSchemaEntry(Catalog &catalog, string name,
+						unique_ptr<PostgresResultSlice> tables,
+	                    unique_ptr<PostgresResultSlice> enums,
+						unique_ptr<PostgresResultSlice> composite_types,
+						unique_ptr<PostgresResultSlice> indexes) :
+    SchemaCatalogEntry(catalog, std::move(name), true),
+	tables(*this, std::move(tables)),
+	indexes(*this, std::move(indexes)),
+	types(*this, std::move(enums), std::move(composite_types)) {
 }
 
 PostgresTransaction &GetPostgresTransaction(CatalogTransaction transaction) {

--- a/src/storage/postgres_schema_entry.cpp
+++ b/src/storage/postgres_schema_entry.cpp
@@ -18,6 +18,13 @@ PostgresSchemaEntry::PostgresSchemaEntry(Catalog &catalog, string name) :
 	types(*this) {
 }
 
+PostgresSchemaEntry::PostgresSchemaEntry(PostgresTransaction &transaction, Catalog &catalog, string name, PostgresResultSlice &table_slice, PostgresResultSlice &enums, PostgresResultSlice &composite_types, PostgresResultSlice &index_slice) :
+    SchemaCatalogEntry(catalog, std::move(name), true), tables(*this), indexes(*this),
+	types(*this) {
+	tables.Initialize(transaction, table_slice);
+	indexes.Initialize(index_slice);
+}
+
 PostgresTransaction &GetPostgresTransaction(CatalogTransaction transaction) {
 	if (!transaction.transaction) {
 		throw InternalException("No transaction!?");
@@ -49,43 +56,9 @@ optional_ptr<CatalogEntry> PostgresSchemaEntry::CreateFunction(CatalogTransactio
 	throw BinderException("Postgres databases do not support creating functions");
 }
 
-void PGUnqualifyColumnReferences(ParsedExpression &expr) {
-	if (expr.type == ExpressionType::COLUMN_REF) {
-		auto &colref = expr.Cast<ColumnRefExpression>();
-		auto name = std::move(colref.column_names.back());
-		colref.column_names = {std::move(name)};
-		return;
-	}
-	ParsedExpressionIterator::EnumerateChildren(expr, PGUnqualifyColumnReferences);
-}
-
-string PGGetCreateIndexSQL(CreateIndexInfo &info, TableCatalogEntry &tbl) {
-	string sql;
-	sql = "CREATE";
-	if (info.constraint_type == IndexConstraintType::UNIQUE) {
-		sql += " UNIQUE";
-	}
-	sql += " INDEX ";
-	sql += KeywordHelper::WriteOptionallyQuoted(info.index_name);
-	sql += " ON ";
-	sql += KeywordHelper::WriteOptionallyQuoted(tbl.name);
-	sql += "(";
-	for (idx_t i = 0; i < info.parsed_expressions.size(); i++) {
-		if (i > 0) {
-			sql += ", ";
-		}
-		PGUnqualifyColumnReferences(*info.parsed_expressions[i]);
-		sql += info.parsed_expressions[i]->ToString();
-	}
-	sql += ")";
-	return sql;
-}
-
 optional_ptr<CatalogEntry> PostgresSchemaEntry::CreateIndex(ClientContext &context, CreateIndexInfo &info,
                                                           TableCatalogEntry &table) {
-	auto &postgres_transaction = PostgresTransaction::Get(context, table.catalog);
-	postgres_transaction.Query(PGGetCreateIndexSQL(info, table));
-	return nullptr;
+	return indexes.CreateIndex(context, info, table);
 }
 
 string PGGetCreateViewSQL(CreateViewInfo &info) {

--- a/src/storage/postgres_schema_set.cpp
+++ b/src/storage/postgres_schema_set.cpp
@@ -1,25 +1,79 @@
 #include "storage/postgres_schema_set.hpp"
+#include "storage/postgres_index_set.hpp"
+#include "storage/postgres_table_set.hpp"
 #include "storage/postgres_transaction.hpp"
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
+#include "storage/postgres_table_set.hpp"
 
 namespace duckdb {
 
 PostgresSchemaSet::PostgresSchemaSet(Catalog &catalog) :
     PostgresCatalogSet(catalog) {}
 
-void PostgresSchemaSet::LoadEntries(ClientContext &context) {
-	auto query = R"(
-SELECT schema_name
-FROM information_schema.schemata;
+vector<PostgresResultSlice> SliceResult(PostgresResult &schemas, PostgresResult &to_slice) {
+	vector<PostgresResultSlice> result;
+	idx_t current_offset = 0;
+	for(idx_t schema_idx = 0; schema_idx < schemas.Count(); schema_idx++) {
+		auto oid = schemas.GetInt64(schema_idx, 0);
+		idx_t start = current_offset;
+		for(; current_offset < to_slice.Count(); current_offset++) {
+			auto current_oid = to_slice.GetInt64(current_offset, 0);
+			if (current_oid != oid) {
+				break;
+			}
+		}
+		result.emplace_back(to_slice, start, current_offset);
+	}
+	return result;
+}
+
+string PostgresSchemaSet::GetInitializeQuery() {
+	return R"(
+SELECT oid, nspname
+FROM pg_namespace
+ORDER BY oid;
 )";
+}
+
+void PostgresSchemaSet::LoadEntries(ClientContext &context) {
+	string schema_query = PostgresSchemaSet::GetInitializeQuery();
+	string tables_query = PostgresTableSet::GetInitializeQuery();
+	string enum_types_query = R"(
+SELECT n.oid, typname, enumtypid, enumsortorder, enumlabel
+FROM pg_enum e
+JOIN pg_type t ON e.enumtypid = t.oid
+JOIN pg_namespace AS n ON (typnamespace=n.oid)
+ORDER BY n.oid, enumtypid, enumsortorder;
+)";
+	string composite_types_query = R"(
+SELECT n.oid, t.oid AS oid, t.typrelid AS id, t.typname as type, t.typtype as typeid, pg_attribute.attname, sub_type.typname
+FROM pg_type t
+JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+JOIN pg_class ON pg_class.oid = t.typrelid
+JOIN pg_attribute ON attrelid=t.typrelid
+JOIN pg_type sub_type ON (pg_attribute.atttypid=sub_type.oid)
+WHERE pg_class.relkind = 'c'
+AND t.typtype='c'
+ORDER BY n.oid, t.oid, attrelid, attnum;
+)";
+	string index_query = PostgresIndexSet::GetInitializeQuery();
+
+	auto full_query = schema_query + tables_query + enum_types_query + composite_types_query + index_query;
 
 	auto &transaction = PostgresTransaction::Get(context, catalog);
-	auto result = transaction.Query(query);
+	auto results = transaction.ExecuteQueries(full_query);
+	auto result = std::move(results[0]);
+	results.erase(results.begin());
 	auto rows = result->Count();
 
+	auto tables = SliceResult(*result, *results[0]);
+	auto enums = SliceResult(*result, *results[1]);
+	auto composite_types = SliceResult(*result, *results[2]);
+	auto indexes = SliceResult(*result, *results[3]);
 	for(idx_t row = 0; row < rows; row++) {
-		auto schema_name = result->GetString(row, 0);
-		auto schema = make_uniq<PostgresSchemaEntry>(catalog, schema_name);
+		auto oid = result->GetInt64(row, 0);
+		auto schema_name = result->GetString(row, 1);
+		auto schema = make_uniq<PostgresSchemaEntry>(transaction, catalog, schema_name, tables[row], enums[row], composite_types[row], indexes[row]);
 		CreateEntry(std::move(schema));
 	}
 }

--- a/src/storage/postgres_table_entry.cpp
+++ b/src/storage/postgres_table_entry.cpp
@@ -43,6 +43,7 @@ TableFunction PostgresTableEntry::GetScanFunction(ClientContext &context, unique
 	result->schema_name = schema.name;
 	result->table_name = name;
 	result->dsn = transaction.GetDSN();
+	result->SetConnection(transaction.GetConnection().GetConnection());
 	result->SetCatalog(pg_catalog);
 	for(auto &col : columns.Logical()) {
 		result->types.push_back(col.GetType());

--- a/src/storage/postgres_table_entry.cpp
+++ b/src/storage/postgres_table_entry.cpp
@@ -37,16 +37,13 @@ void PostgresTableEntry::BindUpdateConstraints(LogicalGet &, LogicalProjection &
 TableFunction PostgresTableEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) {
 	auto &pg_catalog = catalog.Cast<PostgresCatalog>();
 	auto &transaction = Transaction::Get(context, catalog).Cast<PostgresTransaction>();
-	auto &conn = transaction.GetConnection();
 
 	auto result = make_uniq<PostgresBindData>();
 
 	result->schema_name = schema.name;
 	result->table_name = name;
-	result->dsn = conn.GetDSN();
-	result->connection = PostgresConnection(conn.GetConnection());
-
-	PostgresScanFunction::PrepareBind(pg_catalog.GetPostgresVersion(), context, *result);
+	result->dsn = transaction.GetDSN();
+	result->SetCatalog(pg_catalog);
 	for(auto &col : columns.Logical()) {
 		result->types.push_back(col.GetType());
 	}
@@ -54,6 +51,7 @@ TableFunction PostgresTableEntry::GetScanFunction(ClientContext &context, unique
 	result->postgres_types = postgres_types;
 	result->read_only = transaction.IsReadOnly();
 	result->SetTablePages(approx_num_pages);
+	PostgresScanFunction::PrepareBind(pg_catalog.GetPostgresVersion(), context, *result);
 
 	// check how many threads we can actually use
 	if (result->max_threads > 1) {

--- a/src/storage/postgres_table_entry.cpp
+++ b/src/storage/postgres_table_entry.cpp
@@ -50,15 +50,7 @@ TableFunction PostgresTableEntry::GetScanFunction(ClientContext &context, unique
 	result->names = postgres_names;
 	result->postgres_types = postgres_types;
 	result->read_only = transaction.IsReadOnly();
-	result->SetTablePages(approx_num_pages);
-	PostgresScanFunction::PrepareBind(pg_catalog.GetPostgresVersion(), context, *result);
-
-	// check how many threads we can actually use
-	if (result->max_threads > 1) {
-		auto &connection_pool = pg_catalog.GetConnectionPool();
-		result->connection_reservation = connection_pool.AllocateConnections(result->max_threads);
-		result->max_threads = result->connection_reservation.GetConnectionCount();
-	}
+	PostgresScanFunction::PrepareBind(pg_catalog.GetPostgresVersion(), context, *result, approx_num_pages);
 
 	bind_data = std::move(result);
 	auto function = PostgresScanFunction();

--- a/src/storage/postgres_transaction.cpp
+++ b/src/storage/postgres_transaction.cpp
@@ -55,6 +55,20 @@ unique_ptr<PostgresResult> PostgresTransaction::Query(const string &query) {
 	return connection.Query(query);
 }
 
+vector<unique_ptr<PostgresResult>> PostgresTransaction::ExecuteQueries(const string &queries) {
+	if (transaction_state == PostgresTransactionState::TRANSACTION_NOT_YET_STARTED) {
+		transaction_state = PostgresTransactionState::TRANSACTION_STARTED;
+		string transaction_start = "BEGIN TRANSACTION";
+		if (access_mode == AccessMode::READ_ONLY) {
+			transaction_start += " READ ONLY";
+		}
+		transaction_start += ";\n";
+		return connection.ExecuteQueries(transaction_start + queries);
+	}
+	return connection.ExecuteQueries(queries);
+}
+
+
 PostgresTransaction &PostgresTransaction::Get(ClientContext &context, Catalog &catalog) {
 	return Transaction::Get(context, catalog).Cast<PostgresTransaction>();
 }

--- a/src/storage/postgres_transaction.cpp
+++ b/src/storage/postgres_transaction.cpp
@@ -42,6 +42,10 @@ PostgresConnection &PostgresTransaction::GetConnection() {
 	return connection;
 }
 
+PostgresConnection &PostgresTransaction::GetConnectionRaw() {
+	return connection;
+}
+
 unique_ptr<PostgresResult> PostgresTransaction::Query(const string &query) {
 	if (transaction_state == PostgresTransactionState::TRANSACTION_NOT_YET_STARTED) {
 		transaction_state = PostgresTransactionState::TRANSACTION_STARTED;

--- a/src/storage/postgres_type_set.cpp
+++ b/src/storage/postgres_type_set.cpp
@@ -39,7 +39,6 @@ void PostgresTypeSet::LoadEnumTypes(PostgresTransaction &transaction, vector<PGT
 		return;
 	}
 
-	auto &conn = transaction.GetConnection();
 	// compose the query
 	// we create a single big query that uses UNION ALL to get the values of all enums at the same time
 	string query;
@@ -54,7 +53,7 @@ void PostgresTypeSet::LoadEnumTypes(PostgresTransaction &transaction, vector<PGT
 		                            KeywordHelper::WriteQuoted(info.name, '"'));
 	}
 	// now construct the enums
-	auto result = conn.Query(query);
+	auto result = transaction.Query(query);
 	auto count = result->Count();
 	idx_t start = 0;
 	idx_t current_oid = idx_t(-1);
@@ -98,7 +97,6 @@ void PostgresTypeSet::LoadCompositeTypes(PostgresTransaction &transaction, vecto
 	if (composite_info.empty()) {
 		return;
 	}
-	auto &conn = transaction.GetConnection();
 	// compose the query
 	// we create a single big query that uses a big IN list to get the values of all composite types at the same time
 	unordered_map<idx_t, string> name_map;
@@ -116,7 +114,7 @@ FROM pg_attribute JOIN pg_type ON (pg_attribute.atttypid=pg_type.oid)
 WHERE attrelid IN (%s)
 ORDER BY attrelid, attnum;
 )", in_list);
-	auto result = conn.Query(query);
+	auto result = transaction.Query(query);
 	auto count = result->Count();
 	idx_t start = 0;
 	idx_t current_oid = idx_t(-1);
@@ -146,8 +144,7 @@ AND n.nspname=${SCHEMA_NAME};
 )", "${SCHEMA_NAME}", KeywordHelper::WriteQuoted(schema.name));
 
 	auto &transaction = PostgresTransaction::Get(context, catalog);
-	auto &conn = transaction.GetConnection();
-	auto result = conn.Query(query);
+	auto result = transaction.Query(query);
 	auto rows = result->Count();
 	vector<PGTypeInfo> enum_types;
 	vector<PGTypeInfo> composite_types;

--- a/src/storage/postgres_type_set.cpp
+++ b/src/storage/postgres_type_set.cpp
@@ -17,16 +17,26 @@ struct PGTypeInfo {
 PostgresTypeSet::PostgresTypeSet(PostgresSchemaEntry &schema) :
     PostgresCatalogSet(schema.ParentCatalog()), schema(schema) {}
 
+string PostgresTypeSet::GetInitializeEnumsQuery() {
+	return R"(
+SELECT n.oid, enumtypid, typname, enumlabel
+FROM pg_enum e
+JOIN pg_type t ON e.enumtypid = t.oid
+JOIN pg_namespace AS n ON (typnamespace=n.oid)
+ORDER BY n.oid, enumtypid, enumsortorder;
+)";
+}
+
 void PostgresTypeSet::CreateEnum(PostgresResult &result, idx_t start_row, idx_t end_row) {
 	PostgresType postgres_type;
 	CreateTypeInfo info;
-	postgres_type.oid = result.GetInt64(start_row, 0);
-	info.name = result.GetString(start_row, 1);
+	postgres_type.oid = result.GetInt64(start_row, 1);
+	info.name = result.GetString(start_row, 2);
 	// construct the enum
 	idx_t enum_count = end_row - start_row;
 	Vector duckdb_levels(LogicalType::VARCHAR, enum_count);
 	for(idx_t enum_idx = 0; enum_idx < enum_count; enum_idx++) {
-		duckdb_levels.SetValue(enum_idx, result.GetString(start_row + enum_idx, 2));
+		duckdb_levels.SetValue(enum_idx, result.GetString(start_row + enum_idx, 3));
 	}
 	info.type = LogicalType::ENUM(duckdb_levels, enum_count);
 	info.type.SetAlias(info.name);
@@ -34,55 +44,51 @@ void PostgresTypeSet::CreateEnum(PostgresResult &result, idx_t start_row, idx_t 
 	CreateEntry(std::move(type_entry));
 }
 
-void PostgresTypeSet::LoadEnumTypes(PostgresTransaction &transaction, vector<PGTypeInfo> &enum_info) {
-	if (enum_info.empty()) {
-		return;
-	}
-
-	// compose the query
-	// we create a single big query that uses UNION ALL to get the values of all enums at the same time
-	string query;
-	for(auto &info : enum_info) {
-		if (!query.empty()) {
-			query += "\nUNION ALL\n";
-		}
-		query += StringUtil::Format("SELECT %d AS relid, %s AS enum_name, UNNEST(ENUM_RANGE(NULL::%s.%s))::VARCHAR",
-		                            info.oid,
-		                            KeywordHelper::WriteQuoted(info.name, '\''),
-		                            KeywordHelper::WriteQuoted(schema.name, '"'),
-		                            KeywordHelper::WriteQuoted(info.name, '"'));
-	}
-	// now construct the enums
-	auto result = transaction.Query(query);
-	auto count = result->Count();
-	idx_t start = 0;
+void PostgresTypeSet::InitializeEnums(PostgresResultSlice &enums) {
+	auto &result = enums.result;
+	idx_t start = enums.start;
+	idx_t end = enums.end;
 	idx_t current_oid = idx_t(-1);
-	for (idx_t row = 0; row < count; row++) {
-		auto oid = result->GetInt64(row, 0);
+	for (idx_t row = start; row < end; row++) {
+		auto oid = result.GetInt64(row, 1);
 		if (oid != current_oid) {
 			if (row > start) {
-				CreateEnum(*result, start, row);
+				CreateEnum(result, start, row);
 			}
 			start = row;
 			current_oid = oid;
 		}
 	}
-	if (count > start) {
-		CreateEnum(*result, start, count);
+	if (end > start) {
+		CreateEnum(result, start, end);
 	}
 }
 
-void PostgresTypeSet::CreateCompositeType(PostgresTransaction &transaction, PostgresResult &result, idx_t start_row, idx_t end_row, unordered_map<idx_t, string> &name_map) {
+string PostgresTypeSet::GetInitializeCompositesQuery() {
+	return R"(
+SELECT n.oid, t.typrelid AS id, t.typname as type, pg_attribute.attname, sub_type.typname
+FROM pg_type t
+JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+JOIN pg_class ON pg_class.oid = t.typrelid
+JOIN pg_attribute ON attrelid=t.typrelid
+JOIN pg_type sub_type ON (pg_attribute.atttypid=sub_type.oid)
+WHERE pg_class.relkind = 'c'
+AND t.typtype='c'
+ORDER BY n.oid, t.oid, attrelid, attnum;
+)";
+}
+
+void PostgresTypeSet::CreateCompositeType(PostgresTransaction &transaction, PostgresResult &result, idx_t start_row, idx_t end_row) {
 	PostgresType postgres_type;
 	CreateTypeInfo info;
-	postgres_type.oid = result.GetInt64(start_row, 0);
-	info.name = name_map[postgres_type.oid];
+	postgres_type.oid = result.GetInt64(start_row, 1);
+	info.name = result.GetString(start_row, 2);
 
 	child_list_t<LogicalType> child_types;
 	for (idx_t row = start_row; row < end_row; row++) {
-		auto type_name = result.GetString(row, 1);
+		auto type_name = result.GetString(row, 3);
 		PostgresTypeData type_data;
-		type_data.type_name = result.GetString(row, 2);
+		type_data.type_name = result.GetString(row, 4);
 		PostgresType child_type;
 		child_types.push_back(make_pair(type_name, PostgresUtils::TypeToLogicalType(&transaction, &schema, type_data, child_type)));
 		postgres_type.children.push_back(std::move(child_type));
@@ -93,81 +99,37 @@ void PostgresTypeSet::CreateCompositeType(PostgresTransaction &transaction, Post
 	CreateEntry(std::move(type_entry));
 }
 
-void PostgresTypeSet::LoadCompositeTypes(PostgresTransaction &transaction, vector<PGTypeInfo> &composite_info) {
-	if (composite_info.empty()) {
-		return;
-	}
-	// compose the query
-	// we create a single big query that uses a big IN list to get the values of all composite types at the same time
-	unordered_map<idx_t, string> name_map;
-	string in_list;
-	for(auto &info : composite_info) {
-		if (!in_list.empty()) {
-			in_list += ",";
-		}
-		name_map[info.typrelid] = info.name;
-		in_list += to_string(info.typrelid);
-	}
-	string query = StringUtil::Format(R"(
-SELECT attrelid, attname, typname
-FROM pg_attribute JOIN pg_type ON (pg_attribute.atttypid=pg_type.oid)
-WHERE attrelid IN (%s)
-ORDER BY attrelid, attnum;
-)", in_list);
-	auto result = transaction.Query(query);
-	auto count = result->Count();
-	idx_t start = 0;
+void PostgresTypeSet::InitializeCompositeTypes(PostgresTransaction &transaction, PostgresResultSlice &composite_types) {
+	auto &result = composite_types.result;
+	idx_t start = composite_types.start;
+	idx_t end = composite_types.end;
 	idx_t current_oid = idx_t(-1);
-	for (idx_t row = 0; row < count; row++) {
-		auto oid = result->GetInt64(row, 0);
+	for (idx_t row = start; row < end; row++) {
+		auto oid = result.GetInt64(row, 1);
 		if (oid != current_oid) {
 			if (row > start) {
-				CreateCompositeType(transaction, *result, start, row, name_map);
+				CreateCompositeType(transaction, result, start, row);
 			}
 			start = row;
 			current_oid = oid;
 		}
 	}
-	if (count > start) {
-		CreateCompositeType(transaction, *result, start, count, name_map);
+	if (end > start) {
+		CreateCompositeType(transaction, result, start, end);
 	}
 }
 
-void PostgresTypeSet::LoadEntries(ClientContext &context) {
-	auto query = StringUtil::Replace(R"(
-SELECT t.oid AS oid, t.typrelid AS id, t.typname as type, t.typtype as typeid
-FROM pg_type t
-LEFT JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-WHERE (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid))
-AND NOT EXISTS(SELECT 1 FROM pg_catalog.pg_type el WHERE el.oid = t.typelem AND el.typarray = t.oid)
-AND n.nspname=${SCHEMA_NAME};
-)", "${SCHEMA_NAME}", KeywordHelper::WriteQuoted(schema.name));
-
-	auto &transaction = PostgresTransaction::Get(context, catalog);
-	auto result = transaction.Query(query);
-	auto rows = result->Count();
-	vector<PGTypeInfo> enum_types;
-	vector<PGTypeInfo> composite_types;
-	for(idx_t row = 0; row < rows; row++) {
-		auto type = result->GetString(row, 3);
-		if (type != "e" && type != "c") {
-			// unsupported type;
-			continue;
-		}
-		PGTypeInfo info;
-		info.oid = result->GetInt64(row, 0);
-		info.typrelid = result->GetInt64(row, 1);
-		info.name = result->GetString(row, 2);
-		if (type == "e") {
-			// enum
-			enum_types.push_back(std::move(info));
-		} else if (type == "c") {
-			// composite
-			composite_types.push_back(std::move(info));
-		}
+void PostgresTypeSet::Initialize(PostgresTransaction &transaction, PostgresResultSlice &enums, PostgresResultSlice &composite_types) {
+	if (IsLoaded()) {
+		throw InternalException("PostgresTypeSet::Initialize cannot be called on a loaded type set");
 	}
-	LoadEnumTypes(transaction, enum_types);
-	LoadCompositeTypes(transaction, composite_types);
+	SetLoaded();
+	InitializeEnums(enums);
+	InitializeCompositeTypes(transaction, composite_types);
+}
+
+void PostgresTypeSet::LoadEntries(ClientContext &context) {
+	throw InternalException("PostgresTypeSet::LoadEntries not defined");
 }
 
 string GetCreateTypeSQL(CreateTypeInfo &info) {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,7 @@
   "dependencies": [
     "openssl"
   ],
+  "builtin-baseline": "a42af01b72c28a8e1d7b48107b33e4f286a55ef6",
   "overrides": [
     {"name": "openssl", "version": "3.0.8"}
   ]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,8 @@
 {
   "dependencies": [
     "openssl"
+  ],
+  "overrides": [
+    {"name": "openssl", "version": "3.0.8"}
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,9 +1,5 @@
 {
   "dependencies": [
     "openssl"
-  ],
-  "builtin-baseline": "a42af01b72c28a8e1d7b48107b33e4f286a55ef6",
-  "overrides": [
-    {"name": "openssl", "version": "3.0.8"}
   ]
 }


### PR DESCRIPTION
This PR reduces the number of round-trips and reconnects that happen in the Postgres attach and subsequent queries through the following mechanisms:

* Turn the connection pool into an actual connection pool that caches Postgres connections, avoiding the need to reconnect for every transaction
* Avoids running BEGIN TRANSACTION/COMMIT as separate statements unnecessarily when reading small tables
* Fetch the schema/tables/types/indexes in one single set of queries send through `PQsendQuery` instead of running multiple separate queries that incur a round-trip every time
* Fetch enums/composite types and their info in a single query instead of fetching them in two batches (previously we had two queries: (1) figured out which enums existed, (2) figured out the enum values).

#### Performance

Using the [RNA central database](https://rnacentral.org/help/public-database) we get the following performance numbers.

```sql
.timer on
ATTACH 'dbname = pfmegrnargs host = hh-pgsql-public.ebi.ac.uk port = 5432  user = reader password = NWDMCE5xdipIjRrp' AS s (TYPE POSTGRES);
-- first query also loads full schema
-- note that the new version is much faster AND loads more, since ALL schemas/tables are loaded at once
SELECT * FROM s.rnacen.ensembl_assembly;
-- old: 0.872s
-- new: 0.406s
-- psql: 0.10s

-- second time is faster since schema is cached, in new scenario use cached connection
SELECT * FROM s.rnacen.ensembl_assembly;
-- old: 0.27s
-- new: 0.08s
-- psql: 0.10s
```

Note that `psql` beats us at the first query since they merely fire a query rather than loading the catalog/table/etc information.
