### PR TITLE
Fix #154: keep transaction open for legacy postgres_scan function

### DIFF
--- a/src/include/postgres_connection.hpp
+++ b/src/include/postgres_connection.hpp
@@ -22,15 +22,8 @@ class PostgresResult;
 struct IndexInfo;
 
 struct OwnedPostgresConnection {
-	explicit OwnedPostgresConnection(PGconn *conn = nullptr) : connection(conn) {
-	}
-	~OwnedPostgresConnection() {
-		if (!connection) {
-			return;
-		}
-		PQfinish(connection);
-		connection = nullptr;
-	}
+	explicit OwnedPostgresConnection(PGconn *conn = nullptr);
+	~OwnedPostgresConnection();
 
 	PGconn *connection;
 };

--- a/src/postgres_connection.cpp
+++ b/src/postgres_connection.cpp
@@ -8,6 +8,17 @@ namespace duckdb {
 
 static bool debug_postgres_print_queries = false;
 
+OwnedPostgresConnection::OwnedPostgresConnection(PGconn *conn) : connection(conn) {
+}
+
+OwnedPostgresConnection::~OwnedPostgresConnection() {
+	if (!connection) {
+		return;
+	}
+	PQfinish(connection);
+	connection = nullptr;
+}
+
 PostgresConnection::PostgresConnection(shared_ptr<OwnedPostgresConnection> connection_p)
     : connection(std::move(connection_p)) {
 }


### PR DESCRIPTION
Fixes #154