### PR TITLE
Try to reload a table/view definition from Postgres if a table/view is not found

### DIFF
--- a/src/include/storage/postgres_table_set.hpp
+++ b/src/include/storage/postgres_table_set.hpp
@@ -28,7 +28,7 @@ public:
 	                                                  const string &table_name);
 	static unique_ptr<PostgresTableInfo> GetTableInfo(PostgresConnection &connection, const string &schema_name,
 	                                                  const string &table_name);
-	optional_ptr<CatalogEntry> RefreshTable(ClientContext &context, const string &table_name);
+	optional_ptr<CatalogEntry> ReloadEntry(ClientContext &context, const string &table_name) override;
 
 	void AlterTable(ClientContext &context, AlterTableInfo &info);
 
@@ -36,6 +36,9 @@ public:
 
 protected:
 	void LoadEntries(ClientContext &context) override;
+	bool SupportReload() const override {
+		return true;
+	}
 
 	void AlterTable(ClientContext &context, RenameTableInfo &info);
 	void AlterTable(ClientContext &context, RenameColumnInfo &info);
@@ -45,8 +48,7 @@ protected:
 	static void AddColumn(optional_ptr<PostgresTransaction> transaction, optional_ptr<PostgresSchemaEntry> schema,
 	                      PostgresResult &result, idx_t row, PostgresTableInfo &table_info, idx_t column_offset = 0);
 
-	void CreateEntries(PostgresTransaction &transaction, PostgresResult &result, idx_t start, idx_t end,
-	                   idx_t col_offset);
+	void CreateEntries(PostgresTransaction &transaction, PostgresResult &result, idx_t start, idx_t end);
 
 protected:
 	PostgresSchemaEntry &schema;

--- a/src/include/storage/postgres_type_set.hpp
+++ b/src/include/storage/postgres_type_set.hpp
@@ -29,6 +29,10 @@ public:
 	static string GetInitializeCompositesQuery();
 
 protected:
+	bool HasInternalDependencies() const override {
+		// composite types can refer to other types
+		return true;
+	}
 	void LoadEntries(ClientContext &context) override;
 
 	void CreateEnum(PostgresResult &result, idx_t start_row, idx_t end_row);

--- a/src/storage/postgres_schema_entry.cpp
+++ b/src/storage/postgres_schema_entry.cpp
@@ -101,7 +101,7 @@ optional_ptr<CatalogEntry> PostgresSchemaEntry::CreateView(CatalogTransaction tr
 	}
 	auto &postgres_transaction = GetPostgresTransaction(transaction);
 	postgres_transaction.Query(PGGetCreateViewSQL(info));
-	return tables.RefreshTable(transaction.GetContext(), info.view_name);
+	return tables.ReloadEntry(transaction.GetContext(), info.view_name);
 }
 
 optional_ptr<CatalogEntry> PostgresSchemaEntry::CreateType(CatalogTransaction transaction, CreateTypeInfo &info) {

--- a/test/sql/storage/attach_concurrent_queries.test
+++ b/test/sql/storage/attach_concurrent_queries.test
@@ -12,7 +12,7 @@ ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 # concurrent table creation
 concurrentloop i 0 10
 
-statement ok
+statement maybe
 CREATE OR REPLACE TABLE s.concurrent(i INTEGER);
 
 endloop

--- a/test/sql/storage/attach_concurrent_queries.test
+++ b/test/sql/storage/attach_concurrent_queries.test
@@ -9,8 +9,13 @@ require-env POSTGRES_TEST_DATABASE_AVAILABLE
 statement ok
 ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 
+# concurrent table creation
+concurrentloop i 0 10
+
 statement ok
 CREATE OR REPLACE TABLE s.concurrent(i INTEGER);
+
+endloop
 
 # just run a bunch of queries - these may or may not work but they at least should not crash
 concurrentloop i 0 10
@@ -28,3 +33,13 @@ query II
 SELECT SUM(i), COUNT(*) FROM s.concurrent
 ----
 900	100
+
+# query a non-existent table concurrently
+concurrentloop i 0 10
+
+statement error
+SELECT * FROM s.xxxxxxzzz
+----
+xxxxxxzzz
+
+endloop


### PR DESCRIPTION
If a new table is created from within Postgres, the table should now be immediately visible in DuckDB without having to run `CALL pg_clear_cache()`.