### PR TITLE
Add setting pg_experimental_connection_cache that is disabled by default

### DIFF
--- a/src/include/storage/postgres_connection_pool.hpp
+++ b/src/include/storage/postgres_connection_pool.hpp
@@ -49,6 +49,8 @@ public:
 	void ReturnConnection(PostgresConnection connection);
 	void SetMaximumConnections(idx_t new_max);
 
+	static void PostgresSetConnectionCache(ClientContext &context, SetScope scope, Value &parameter);
+
 private:
 	PostgresCatalog &postgres_catalog;
 	mutex connection_lock;

--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -64,6 +64,9 @@ static void LoadInternal(DatabaseInstance &db) {
 	config.AddExtensionOption("pg_array_as_varchar",
 	                          "Read Postgres arrays as varchar - enables reading mixed dimensional arrays",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(false));
+	config.AddExtensionOption("pg_experimental_connection_cache",
+							  "Whether or not to use the connection cache (currently experimental)", LogicalType::BOOLEAN,
+							  Value::BOOLEAN(false), PostgresConnectionPool::PostgresSetConnectionCache);
 	config.AddExtensionOption("pg_experimental_filter_pushdown",
 	                          "Whether or not to use filter pushdown (currently experimental)", LogicalType::BOOLEAN,
 	                          Value::BOOLEAN(false));

--- a/src/storage/postgres_connection_pool.cpp
+++ b/src/storage/postgres_connection_pool.cpp
@@ -2,6 +2,7 @@
 #include "storage/postgres_catalog.hpp"
 
 namespace duckdb {
+static bool pg_use_connection_cache = false;
 
 PostgresPoolConnection::PostgresPoolConnection() : pool(nullptr) {
 }
@@ -61,6 +62,13 @@ bool PostgresConnectionPool::TryGetConnection(PostgresPoolConnection &connection
 	return true;
 }
 
+void PostgresConnectionPool::PostgresSetConnectionCache(ClientContext &context, SetScope scope, Value &parameter) {
+	if (parameter.IsNull()) {
+		throw BinderException("Cannot be set to NULL");
+	}
+	pg_use_connection_cache = BooleanValue::Get(parameter);
+}
+
 PostgresPoolConnection PostgresConnectionPool::GetConnection() {
 	PostgresPoolConnection result;
 	if (!TryGetConnection(result)) {
@@ -80,6 +88,9 @@ void PostgresConnectionPool::ReturnConnection(PostgresConnection connection) {
 	if (active_connections >= maximum_connections) {
 		// if the maximum number of connections has been decreased by the user we might need to reclaim the connection
 		// immediately
+		return;
+	}
+	if (!pg_use_connection_cache) {
 		return;
 	}
 	// check if the underlying connection is still usable

--- a/test/sql/storage/attach_connection_pool.test
+++ b/test/sql/storage/attach_connection_pool.test
@@ -7,6 +7,9 @@ require postgres_scanner
 require-env POSTGRES_TEST_DATABASE_AVAILABLE
 
 statement ok
+SET pg_experimental_connection_cache=true
+
+statement ok
 SET pg_connection_limit=1000
 
 statement ok


### PR DESCRIPTION
#142 introduced a connection cache - however, keeping connections cached is not super trivial because there is state associated with an open connection. I suspect that this might be causing some issues, so this marks the connection cache as experimental. It can be enabled with a setting (`SET pg_experimental_connection_cache=true`) and is disabled by default for now.