### PR TITLE
Add PostgresViewEntry

### DIFF
--- a/src/include/storage/postgres_create_info.hpp
+++ b/src/include/storage/postgres_create_info.hpp
@@ -18,11 +18,14 @@ struct PostgresCreateInfo {
 public:
 	PostgresCreateInfo() {
 	}
-	virtual ~PostgresCreateInfo() {}
+	virtual ~PostgresCreateInfo() {
+	}
+
 public:
 	virtual CreateInfo &GetCreateInfo() = 0;
 	virtual const string &GetName() const = 0;
 	virtual void AddColumn(ColumnDefinition def, PostgresType pg_type, const string &pg_name) = 0;
+
 public:
 	template <class TARGET>
 	TARGET &Cast() {
@@ -35,6 +38,7 @@ public:
 		D_ASSERT(dynamic_cast<const TARGET *>(this));
 		return reinterpret_cast<const TARGET &>(*this);
 	}
+
 public:
 	idx_t approx_num_pages = 0;
 };

--- a/src/include/storage/postgres_create_info.hpp
+++ b/src/include/storage/postgres_create_info.hpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/postgres_create_info.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "postgres_utils.hpp"
+
+namespace duckdb {
+
+struct PostgresCreateInfo {
+public:
+	PostgresCreateInfo() {
+	}
+	virtual ~PostgresCreateInfo() {}
+public:
+	virtual CreateInfo &GetCreateInfo() = 0;
+	virtual const string &GetName() const = 0;
+	virtual void AddColumn(ColumnDefinition def, PostgresType pg_type, const string &pg_name) = 0;
+public:
+	template <class TARGET>
+	TARGET &Cast() {
+		D_ASSERT(dynamic_cast<TARGET *>(this));
+		return reinterpret_cast<TARGET &>(*this);
+	}
+
+	template <class TARGET>
+	const TARGET &Cast() const {
+		D_ASSERT(dynamic_cast<const TARGET *>(this));
+		return reinterpret_cast<const TARGET &>(*this);
+	}
+public:
+	idx_t approx_num_pages = 0;
+};
+
+} // namespace duckdb

--- a/src/include/storage/postgres_table_entry.hpp
+++ b/src/include/storage/postgres_table_entry.hpp
@@ -29,9 +29,10 @@ public:
 		create_info = make_uniq<CreateTableInfo>((SchemaCatalogEntry &)schema, table);
 		create_info->columns.SetAllowDuplicates(true);
 	}
-	~PostgresTableInfo() override {}
-public:
+	~PostgresTableInfo() override {
+	}
 
+public:
 	CreateInfo &GetCreateInfo() override {
 		return *create_info;
 	}

--- a/src/include/storage/postgres_table_set.hpp
+++ b/src/include/storage/postgres_table_set.hpp
@@ -46,7 +46,8 @@ protected:
 	void AlterTable(ClientContext &context, RemoveColumnInfo &info);
 
 	static void AddColumn(optional_ptr<PostgresTransaction> transaction, optional_ptr<PostgresSchemaEntry> schema,
-	                      PostgresResult &result, idx_t row, PostgresCreateInfo &pg_create_info, idx_t column_offset = 0);
+	                      PostgresResult &result, idx_t row, PostgresCreateInfo &pg_create_info,
+	                      idx_t column_offset = 0);
 
 	void CreateEntries(PostgresTransaction &transaction, PostgresResult &result, idx_t start, idx_t end);
 

--- a/src/include/storage/postgres_table_set.hpp
+++ b/src/include/storage/postgres_table_set.hpp
@@ -46,7 +46,7 @@ protected:
 	void AlterTable(ClientContext &context, RemoveColumnInfo &info);
 
 	static void AddColumn(optional_ptr<PostgresTransaction> transaction, optional_ptr<PostgresSchemaEntry> schema,
-	                      PostgresResult &result, idx_t row, PostgresTableInfo &table_info, idx_t column_offset = 0);
+	                      PostgresResult &result, idx_t row, PostgresCreateInfo &pg_create_info, idx_t column_offset = 0);
 
 	void CreateEntries(PostgresTransaction &transaction, PostgresResult &result, idx_t start, idx_t end);
 

--- a/src/include/storage/postgres_view_entry.hpp
+++ b/src/include/storage/postgres_view_entry.hpp
@@ -28,8 +28,8 @@ public:
 		create_info = make_uniq<CreateViewInfo>((SchemaCatalogEntry &)schema, view);
 		// create_info->columns.SetAllowDuplicates(true);
 	}
-public:
 
+public:
 	const string &GetName() const override {
 		return create_info->view_name;
 	}
@@ -55,6 +55,7 @@ class PostgresViewEntry : public ViewCatalogEntry {
 public:
 	PostgresViewEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateViewInfo &info);
 	PostgresViewEntry(Catalog &catalog, SchemaCatalogEntry &schema, PostgresViewInfo &info);
+
 public:
 	//! Postgres type annotations
 	vector<PostgresType> postgres_types;

--- a/src/include/storage/postgres_view_entry.hpp
+++ b/src/include/storage/postgres_view_entry.hpp
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// storage/postgres_view_entry.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
+#include "duckdb/parser/parsed_data/create_view_info.hpp"
+#include "storage/postgres_create_info.hpp"
+
+namespace duckdb {
+
+struct PostgresViewInfo : public PostgresCreateInfo {
+public:
+	PostgresViewInfo() {
+		create_info = make_uniq<CreateViewInfo>();
+		// create_info->columns.SetAllowDuplicates(true);
+	}
+	PostgresViewInfo(const string &schema, const string &view) {
+		create_info = make_uniq<CreateViewInfo>(string(), schema, view);
+		// create_info->columns.SetAllowDuplicates(true);
+	}
+	PostgresViewInfo(const SchemaCatalogEntry &schema, const string &view) {
+		create_info = make_uniq<CreateViewInfo>((SchemaCatalogEntry &)schema, view);
+		// create_info->columns.SetAllowDuplicates(true);
+	}
+public:
+
+	const string &GetName() const override {
+		return create_info->view_name;
+	}
+
+	CreateInfo &GetCreateInfo() override {
+		return *create_info;
+	}
+
+	void AddColumn(ColumnDefinition def, PostgresType pg_type, const string &pg_name) override {
+		postgres_types.push_back(std::move(pg_type));
+		postgres_names.push_back(pg_name);
+		create_info->types.push_back(def.Type());
+		create_info->names.push_back(def.Name());
+	}
+
+public:
+	unique_ptr<CreateViewInfo> create_info;
+	vector<PostgresType> postgres_types;
+	vector<string> postgres_names;
+};
+
+class PostgresViewEntry : public ViewCatalogEntry {
+public:
+	PostgresViewEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateViewInfo &info);
+	PostgresViewEntry(Catalog &catalog, SchemaCatalogEntry &schema, PostgresViewInfo &info);
+public:
+	//! Postgres type annotations
+	vector<PostgresType> postgres_types;
+	//! Column names as they are within Postgres
+	//! We track these separately because of case sensitivity - Postgres allows e.g. the columns "ID" and "id" together
+	//! We would in this case remap them to "ID" and "id_1", while postgres_names store the original names
+	vector<string> postgres_names;
+	//! The approximate number of pages a table consumes in Postgres
+	idx_t approx_num_pages;
+};
+
+} // namespace duckdb

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -18,7 +18,9 @@ add_library(
   postgres_transaction_manager.cpp
   postgres_type_entry.cpp
   postgres_type_set.cpp
-  postgres_update.cpp)
+  postgres_update.cpp
+  postgres_view_entry.cpp
+  )
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:postgres_ext_storage>
     PARENT_SCOPE)

--- a/src/storage/postgres_catalog_set.cpp
+++ b/src/storage/postgres_catalog_set.cpp
@@ -105,8 +105,8 @@ void PostgresCatalogSet::ClearEntries() {
 	is_loaded = false;
 }
 
-PostgresInSchemaSet::PostgresInSchemaSet(PostgresSchemaEntry &schema, bool is_loaded) :
-	PostgresCatalogSet(schema.ParentCatalog(), is_loaded), schema(schema) {
+PostgresInSchemaSet::PostgresInSchemaSet(PostgresSchemaEntry &schema, bool is_loaded)
+    : PostgresCatalogSet(schema.ParentCatalog(), is_loaded), schema(schema) {
 }
 
 optional_ptr<CatalogEntry> PostgresInSchemaSet::CreateEntry(unique_ptr<CatalogEntry> entry) {

--- a/src/storage/postgres_schema_entry.cpp
+++ b/src/storage/postgres_schema_entry.cpp
@@ -17,12 +17,12 @@ PostgresSchemaEntry::PostgresSchemaEntry(Catalog &catalog, CreateSchemaInfo &inf
     : SchemaCatalogEntry(catalog, info), tables(*this), indexes(*this), types(*this) {
 }
 
-PostgresSchemaEntry::PostgresSchemaEntry(Catalog &catalog, CreateSchemaInfo &info, unique_ptr<PostgresResultSlice> tables,
-                                         unique_ptr<PostgresResultSlice> enums,
+PostgresSchemaEntry::PostgresSchemaEntry(Catalog &catalog, CreateSchemaInfo &info,
+                                         unique_ptr<PostgresResultSlice> tables, unique_ptr<PostgresResultSlice> enums,
                                          unique_ptr<PostgresResultSlice> composite_types,
                                          unique_ptr<PostgresResultSlice> indexes)
-    : SchemaCatalogEntry(catalog, info), tables(*this, std::move(tables)),
-      indexes(*this, std::move(indexes)), types(*this, std::move(enums), std::move(composite_types)) {
+    : SchemaCatalogEntry(catalog, info), tables(*this, std::move(tables)), indexes(*this, std::move(indexes)),
+      types(*this, std::move(enums), std::move(composite_types)) {
 }
 
 bool PostgresSchemaEntry::SchemaIsInternal(const string &name) {

--- a/src/storage/postgres_schema_set.cpp
+++ b/src/storage/postgres_schema_set.cpp
@@ -61,12 +61,11 @@ void PostgresSchemaSet::LoadEntries(ClientContext &context) {
 	for (idx_t row = 0; row < rows; row++) {
 		auto oid = result->GetInt64(row, 0);
 		auto schema_name = result->GetString(row, 1);
-                CreateSchemaInfo info;
-                info.schema = schema_name;
-                info.internal = PostgresSchemaEntry::SchemaIsInternal(schema_name);
-		auto schema =
-		    make_uniq<PostgresSchemaEntry>(catalog, info, std::move(tables[row]), std::move(enums[row]),
-		                                   std::move(composite_types[row]), std::move(indexes[row]));
+		CreateSchemaInfo info;
+		info.schema = schema_name;
+		info.internal = PostgresSchemaEntry::SchemaIsInternal(schema_name);
+		auto schema = make_uniq<PostgresSchemaEntry>(catalog, info, std::move(tables[row]), std::move(enums[row]),
+		                                             std::move(composite_types[row]), std::move(indexes[row]));
 		CreateEntry(std::move(schema));
 	}
 }
@@ -76,8 +75,8 @@ optional_ptr<CatalogEntry> PostgresSchemaSet::CreateSchema(ClientContext &contex
 
 	string create_sql = "CREATE SCHEMA " + KeywordHelper::WriteQuoted(info.schema, '"');
 	transaction.Query(create_sql);
-        auto info_copy = info.Copy();
-        info.internal = PostgresSchemaEntry::SchemaIsInternal(info_copy->schema);
+	auto info_copy = info.Copy();
+	info.internal = PostgresSchemaEntry::SchemaIsInternal(info_copy->schema);
 	auto schema_entry = make_uniq<PostgresSchemaEntry>(catalog, info_copy->Cast<CreateSchemaInfo>());
 	return CreateEntry(std::move(schema_entry));
 }

--- a/src/storage/postgres_table_set.cpp
+++ b/src/storage/postgres_table_set.cpp
@@ -80,15 +80,16 @@ void PostgresTableSet::CreateEntries(PostgresTransaction &transaction, PostgresR
 			}
 			auto catalog_type = TransformRelKind(relkind);
 			switch (catalog_type) {
-				case CatalogType::TABLE_ENTRY:
-					info = make_uniq<PostgresTableInfo>(schema, relname);
-					break;
-				case CatalogType::VIEW_ENTRY:
-					info = make_uniq<PostgresViewInfo>(schema, relname);
-					break;
-				default: {
-					throw InternalException("Unexpected CatalogType in CreateEntries: %s", CatalogTypeToString(catalog_type));
-				}
+			case CatalogType::TABLE_ENTRY:
+				info = make_uniq<PostgresTableInfo>(schema, relname);
+				break;
+			case CatalogType::VIEW_ENTRY:
+				info = make_uniq<PostgresViewInfo>(schema, relname);
+				break;
+			default: {
+				throw InternalException("Unexpected CatalogType in CreateEntries: %s",
+				                        CatalogTypeToString(catalog_type));
+			}
 				info->approx_num_pages = approx_num_pages;
 			}
 		}
@@ -101,15 +102,15 @@ void PostgresTableSet::CreateEntries(PostgresTransaction &transaction, PostgresR
 		auto &create_info = pg_create_info->GetCreateInfo();
 		unique_ptr<StandardEntry> catalog_entry;
 		switch (create_info.type) {
-			case CatalogType::TABLE_ENTRY:
-				catalog_entry = make_uniq<PostgresTableEntry>(catalog, schema, pg_create_info->Cast<PostgresTableInfo>());
-				break;
-			case CatalogType::VIEW_ENTRY:
-				catalog_entry = make_uniq<PostgresViewEntry>(catalog, schema, pg_create_info->Cast<PostgresViewInfo>());
-				break;
-			default: {
-				throw InternalException("Unexpected CatalogType in CreateInfo: %s", CatalogTypeToString(create_info.type));
-			}
+		case CatalogType::TABLE_ENTRY:
+			catalog_entry = make_uniq<PostgresTableEntry>(catalog, schema, pg_create_info->Cast<PostgresTableInfo>());
+			break;
+		case CatalogType::VIEW_ENTRY:
+			catalog_entry = make_uniq<PostgresViewEntry>(catalog, schema, pg_create_info->Cast<PostgresViewInfo>());
+			break;
+		default: {
+			throw InternalException("Unexpected CatalogType in CreateInfo: %s", CatalogTypeToString(create_info.type));
+		}
 		}
 		CreateEntry(std::move(catalog_entry));
 	}

--- a/src/storage/postgres_view_entry.cpp
+++ b/src/storage/postgres_view_entry.cpp
@@ -1,0 +1,32 @@
+#include "storage/postgres_catalog.hpp"
+#include "storage/postgres_view_entry.hpp"
+#include "storage/postgres_transaction.hpp"
+#include "duckdb/storage/statistics/base_statistics.hpp"
+#include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
+#include "postgres_scanner.hpp"
+
+namespace duckdb {
+
+PostgresViewEntry::PostgresViewEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateViewInfo &info)
+    : ViewCatalogEntry(catalog, schema, info) {
+	idx_t column_count = types.size();
+	for (idx_t c = 0; c < column_count; c++) {
+		auto &type = types[c];
+		auto &name = names[c];
+		if (type.HasAlias()) {
+			type = PostgresUtils::RemoveAlias(type);
+		}
+		postgres_types.push_back(PostgresUtils::CreateEmptyPostgresType(type));
+		postgres_names.push_back(name);
+	}
+	approx_num_pages = 0;
+}
+
+PostgresViewEntry::PostgresViewEntry(Catalog &catalog, SchemaCatalogEntry &schema, PostgresViewInfo &info)
+    : ViewCatalogEntry(catalog, schema, *info.create_info), postgres_types(std::move(info.postgres_types)),
+      postgres_names(std::move(info.postgres_names)) {
+	D_ASSERT(postgres_types.size() == types.size());
+	approx_num_pages = info.approx_num_pages;
+}
+
+} // namespace duckdb

--- a/test/other.sql
+++ b/test/other.sql
@@ -131,6 +131,8 @@ CREATE TABLE dum();
 CREATE TABLE dee();
 INSERT INTO dee DEFAULT VALUES;
 
+CREATE VIEW dee_view as select * from dee;
+
 -- table with duplicate column names
 CREATE TABLE tbl_with_case_sensitive_columns (
 	"MyColumn" INT,

--- a/test/sql/storage/attach_information_schema.test
+++ b/test/sql/storage/attach_information_schema.test
@@ -1,0 +1,19 @@
+# name: test/sql/storage/attach_describe.test
+# description: Test DESCRIBE
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgres' AS s1 (TYPE POSTGRES)
+
+query IIII
+select table_catalog, table_schema, table_name, table_type  from information_schema.tables where table_name in ('v','s','t');
+----
+s1	public	t	BASE TABLE
+s1	public	v	VIEW

--- a/test/sql/storage/attach_information_schema.test
+++ b/test/sql/storage/attach_information_schema.test
@@ -13,7 +13,12 @@ statement ok
 ATTACH 'dbname=postgres' AS s1 (TYPE POSTGRES)
 
 query IIII
-select table_catalog, table_schema, table_name, table_type  from information_schema.tables where table_name in ('v','s','t');
+select
+	table_catalog,
+	table_schema,
+	table_name,
+	table_type
+from information_schema.tables where table_name in ('v','s','t') and table_name LIKE 'dee%';
 ----
-s1	public	t	BASE TABLE
-s1	public	v	VIEW
+s1	public	dee	BASE TABLE
+s1	public	dee_view	VIEW


### PR DESCRIPTION
In the table query we get both tables, views, materialized views, partitioned tables and foreign tables.
The views are then stored in the catalog as a TableCatalogEntry, which confuses `duckdb_tables()` and `duckdb_views()` which is used inside `information_schema.tables`

So the views showed up as tables, this PR fixes that and adds a test for it