### PR TITLE
Bump DuckDB to v0.10.1

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build extension binaries
     uses: duckdb/duckdb/.github/workflows/_extension_distribution.yml@3fbbd15390059b8028ad6dfd56a3172e5ebc0ab8
     with:
-      duckdb_version: v0.10.0
+      duckdb_version: v0.10.1
       extension_name: postgres_scanner
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
 
@@ -26,7 +26,7 @@ jobs:
     uses: duckdb/duckdb/.github/workflows/_extension_deploy.yml@3fbbd15390059b8028ad6dfd56a3172e5ebc0ab8
     secrets: inherit
     with:
-      duckdb_version: v0.10.0
+      duckdb_version: v0.10.1
       extension_name: postgres_scanner
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/test/sql/storage/attach_types.test
+++ b/test/sql/storage/attach_types.test
@@ -36,7 +36,7 @@ NULL	NULL	NULL	NULL
 # test all types
 statement ok
 CREATE TABLE all_types_tbl AS SELECT *
-EXCLUDE (float, double, ubigint, hugeint, uhugeint, nested_int_array, struct, struct_of_arrays, array_of_structs, map, "union")
+EXCLUDE (float, double, ubigint, hugeint, uhugeint, nested_int_array, struct, struct_of_arrays, array_of_structs, map, "union", fixed_int_array, fixed_varchar_array, fixed_nested_int_array, fixed_nested_varchar_array, fixed_struct_array, struct_of_fixed_array, fixed_array_of_int_list, list_of_fixed_int_array)
 REPLACE(
 	CASE WHEN int IS NOT NULL THEN '2000-01-01' ELSE NULL END AS date,
 	CASE WHEN int IS NOT NULL THEN '2000-01-01 01:02:03' ELSE NULL END AS timestamp,


### PR DESCRIPTION
Fixes https://github.com/duckdb/postgres_scanner/pull/191.

I have removed all newly added types to test_all_types, but this might not be strictly needed since some of them might be supported. To be reviewed whether some can be added back.