### PR TITLE
Add support for a new postgres_execute function that can be used to execute arbitrary queries within Postgres

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(
   postgres_connection.cpp
   postgres_copy_from.cpp
   postgres_copy_to.cpp
+  postgres_execute.cpp
   postgres_extension.cpp
   postgres_filter_pushdown.cpp
   postgres_query.cpp

--- a/src/include/postgres_scanner.hpp
+++ b/src/include/postgres_scanner.hpp
@@ -91,4 +91,9 @@ public:
 	PostgresQueryFunction();
 };
 
+class PostgresExecuteFunction : public TableFunction {
+public:
+	PostgresExecuteFunction();
+};
+
 } // namespace duckdb

--- a/src/postgres_execute.cpp
+++ b/src/postgres_execute.cpp
@@ -1,0 +1,57 @@
+#include "duckdb.hpp"
+
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "postgres_scanner.hpp"
+#include "duckdb/main/database_manager.hpp"
+#include "duckdb/main/attached_database.hpp"
+#include "storage/postgres_catalog.hpp"
+#include "storage/postgres_transaction.hpp"
+
+namespace duckdb {
+
+struct PGExecuteBindData : public TableFunctionData {
+	explicit PGExecuteBindData(PostgresCatalog &pg_catalog, string query_p)
+	    : pg_catalog(pg_catalog), query(std::move(query_p)) {
+	}
+
+	bool finished = false;
+	PostgresCatalog &pg_catalog;
+	string query;
+};
+
+static duckdb::unique_ptr<FunctionData> PGExecuteBind(ClientContext &context, TableFunctionBindInput &input,
+                                                      vector<LogicalType> &return_types, vector<string> &names) {
+	return_types.emplace_back(LogicalType::BOOLEAN);
+	names.emplace_back("Success");
+
+	// look up the database to query
+	auto db_name = input.inputs[0].GetValue<string>();
+	auto &db_manager = DatabaseManager::Get(context);
+	auto db = db_manager.GetDatabase(context, db_name);
+	if (!db) {
+		throw BinderException("Failed to find attached database \"%s\" referenced in postgres_query", db_name);
+	}
+	auto &catalog = db->GetCatalog();
+	if (catalog.GetCatalogType() != "postgres") {
+		throw BinderException("Attached database \"%s\" does not refer to a Postgres database", db_name);
+	}
+	auto &pg_catalog = catalog.Cast<PostgresCatalog>();
+	return make_uniq<PGExecuteBindData>(pg_catalog, input.inputs[1].GetValue<string>());
+}
+
+static void PGExecuteFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.bind_data->CastNoConst<PGExecuteBindData>();
+	if (data.finished) {
+		return;
+	}
+	auto &transaction = Transaction::Get(context, data.pg_catalog).Cast<PostgresTransaction>();
+	transaction.ExecuteQueries(data.query);
+	data.finished = true;
+}
+
+PostgresExecuteFunction::PostgresExecuteFunction()
+    : TableFunction("postgres_execute", {LogicalType::VARCHAR, LogicalType::VARCHAR}, PGExecuteFunction,
+                    PGExecuteBind) {
+}
+
+} // namespace duckdb

--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -87,6 +87,9 @@ static void LoadInternal(DatabaseInstance &db) {
 	PostgresQueryFunction query_func;
 	ExtensionUtil::RegisterFunction(db, query_func);
 
+	PostgresExecuteFunction execute_func;
+	ExtensionUtil::RegisterFunction(db, execute_func);
+
 	auto &config = DBConfig::GetConfig(db);
 	config.storage_extensions["postgres_scanner"] = make_uniq<PostgresStorageExtension>();
 

--- a/test/sql/storage/attach_postgres_execute.test
+++ b/test/sql/storage/attach_postgres_execute.test
@@ -1,0 +1,32 @@
+# name: test/sql/storage/attach_postgres_execute.test
+# description: Test attaching postgres execute
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES);
+
+statement ok
+CALL postgres_execute('s', 'DROP TABLE IF EXISTS my_unlogged_table')
+
+statement ok
+CALL postgres_execute('s', 'CREATE UNLOGGED TABLE public.my_unlogged_table(i INTEGER)')
+
+statement ok
+INSERT INTO s.my_unlogged_table VALUES(42)
+
+query I
+FROM s.my_unlogged_table
+----
+42
+
+statement error
+CALL postgres_execute('s', 'CREATE TABLE public.my_unlogged_table(i INTEGER)')
+----
+already exists

--- a/test/sql/storage/attach_read_only.test
+++ b/test/sql/storage/attach_read_only.test
@@ -16,3 +16,8 @@ statement error
 CREATE TABLE s.read_only_tbl(i INTEGER);
 ----
 read-only mode
+
+statement error
+CALL postgres_execute('s', 'CREATE UNLOGGED TABLE public.my_unlogged_table(i INTEGER)')
+----
+read-only


### PR DESCRIPTION
Usage:

```sql
ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES);
CALL postgres_execute('s', 'CREATE TABLE my_table(i INTEGER)');
```