### PR TITLE
Fix #181 - use version() instead, and if version query fails default to unknown version

### DIFF
--- a/src/include/postgres_version.hpp
+++ b/src/include/postgres_version.hpp
@@ -12,7 +12,7 @@
 
 namespace duckdb {
 
-enum class PostgresInstanceType { POSTGRES, AURORA };
+enum class PostgresInstanceType { UNKNOWN, POSTGRES, AURORA };
 
 struct PostgresVersion {
 	PostgresVersion() {

--- a/src/postgres_connection.cpp
+++ b/src/postgres_connection.cpp
@@ -119,7 +119,12 @@ vector<unique_ptr<PostgresResult>> PostgresConnection::ExecuteQueries(const stri
 
 PostgresVersion PostgresConnection::GetPostgresVersion() {
 	auto result =
-	    Query("SELECT CURRENT_SETTING('server_version'), (SELECT COUNT(*) FROM pg_settings WHERE name LIKE 'rds%')");
+	    TryQuery("SELECT version(), (SELECT COUNT(*) FROM pg_settings WHERE name LIKE 'rds%')");
+	if (!result) {
+		PostgresVersion version;
+		version.type_v = PostgresInstanceType::UNKNOWN;
+		return version;
+	}
 	auto version = PostgresUtils::ExtractPostgresVersion(result->GetString(0, 0));
 	if (result->GetInt64(0, 1) > 0) {
 		version.type_v = PostgresInstanceType::AURORA;

--- a/src/postgres_utils.cpp
+++ b/src/postgres_utils.cpp
@@ -434,6 +434,9 @@ uint32_t PostgresUtils::ToPostgresOid(const LogicalType &input) {
 PostgresVersion PostgresUtils::ExtractPostgresVersion(const string &version_str) {
 	PostgresVersion result;
 	idx_t pos = 0;
+	if (!StringUtil::Contains(version_str, "PostgreSQL")) {
+		result.type_v = PostgresInstanceType::UNKNOWN;
+	}
 	// scan for the first digit
 	while (pos < version_str.size() && !StringUtil::CharacterIsDigit(version_str[pos])) {
 		pos++;


### PR DESCRIPTION
Fixes #181 