### PR TITLE
Add pg_use_ctid_scan setting, disable parallel ctid scans by default on older postgres versions

### DIFF
--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -92,6 +92,8 @@ static void LoadInternal(DatabaseInstance &db) {
 
 	config.AddExtensionOption("pg_use_binary_copy", "Whether or not to use BINARY copy to read data",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(true));
+	config.AddExtensionOption("pg_use_ctid_scan", "Whether or not to parallelize scanning using table ctids",
+							  LogicalType::BOOLEAN, Value::BOOLEAN(true));
 	config.AddExtensionOption("pg_pages_per_task", "The amount of pages per task", LogicalType::UBIGINT,
 	                          Value::UBIGINT(PostgresBindData::DEFAULT_PAGES_PER_TASK));
 	config.AddExtensionOption("pg_connection_limit", "The maximum amount of concurrent Postgres connections",

--- a/test/sql/storage/attach_verify_big_table.test_slow
+++ b/test/sql/storage/attach_verify_big_table.test_slow
@@ -20,3 +20,11 @@ SELECT COUNT(*), SUM(generate_series) FROM s1.big_generated_table
 1000000	499999500000
 
 endloop
+
+statement ok
+SET pg_use_ctid_scan=false;
+
+query II
+SELECT COUNT(*), SUM(generate_series) FROM s1.big_generated_table
+----
+1000000	499999500000


### PR DESCRIPTION
Fixes https://github.com/duckdb/postgres_scanner/issues/186