### PR TITLE
Fix #190 - Query constraints from Postgres metadata

### DIFF
--- a/src/include/postgres_binary_reader.hpp
+++ b/src/include/postgres_binary_reader.hpp
@@ -263,9 +263,10 @@ public:
 		return (config.is_negative ? -base_res : base_res);
 	}
 
-	void ReadGeometry(const LogicalType &type, const PostgresType &postgres_type, Vector &out_vec, idx_t output_offset) {
+	void ReadGeometry(const LogicalType &type, const PostgresType &postgres_type, Vector &out_vec,
+	                  idx_t output_offset) {
 		idx_t element_count = 0;
-		switch(postgres_type.info) {
+		switch (postgres_type.info) {
 		case PostgresTypeAnnotation::GEOM_LINE:
 		case PostgresTypeAnnotation::GEOM_CIRCLE:
 			element_count = 3;
@@ -294,7 +295,7 @@ public:
 		list_entries[output_offset].length = element_count;
 		auto &child_vector = ListVector::GetEntry(out_vec);
 		auto child_data = FlatVector::GetData<double>(child_vector);
-		for(idx_t i = 0; i < element_count; i++) {
+		for (idx_t i = 0; i < element_count; i++) {
 			child_data[child_offset + i] = ReadDouble();
 		}
 		ListVector::SetListSize(out_vec, child_offset + element_count);
@@ -488,7 +489,7 @@ public:
 				list_entry.length = 0;
 				break;
 			}
-			switch(postgres_type.info) {
+			switch (postgres_type.info) {
 			case PostgresTypeAnnotation::GEOM_LINE:
 			case PostgresTypeAnnotation::GEOM_LINE_SEGMENT:
 			case PostgresTypeAnnotation::GEOM_BOX:

--- a/src/include/storage/postgres_schema_entry.hpp
+++ b/src/include/storage/postgres_schema_entry.hpp
@@ -44,7 +44,7 @@ public:
 	void DropEntry(ClientContext &context, DropInfo &info) override;
 	optional_ptr<CatalogEntry> GetEntry(CatalogTransaction transaction, CatalogType type, const string &name) override;
 
-        static bool SchemaIsInternal(const string &name);
+	static bool SchemaIsInternal(const string &name);
 
 private:
 	void AlterTable(PostgresTransaction &transaction, RenameTableInfo &info);

--- a/src/include/storage/postgres_table_set.hpp
+++ b/src/include/storage/postgres_table_set.hpp
@@ -32,7 +32,7 @@ public:
 
 	void AlterTable(ClientContext &context, AlterTableInfo &info);
 
-	static string GetInitializeQuery();
+	static string GetInitializeQuery(const string &schema = string(), const string &table = string());
 
 protected:
 	void LoadEntries(ClientContext &context) override;
@@ -46,7 +46,11 @@ protected:
 	void AlterTable(ClientContext &context, RemoveColumnInfo &info);
 
 	static void AddColumn(optional_ptr<PostgresTransaction> transaction, optional_ptr<PostgresSchemaEntry> schema,
-	                      PostgresResult &result, idx_t row, PostgresTableInfo &table_info, idx_t column_offset = 0);
+	                      PostgresResult &result, idx_t row, PostgresTableInfo &table_info);
+	static void AddConstraint(PostgresResult &result, idx_t row, PostgresTableInfo &table_info);
+	static void AddColumnOrConstraint(optional_ptr<PostgresTransaction> transaction,
+	                                  optional_ptr<PostgresSchemaEntry> schema, PostgresResult &result, idx_t row,
+	                                  PostgresTableInfo &table_info);
 
 	void CreateEntries(PostgresTransaction &transaction, PostgresResult &result, idx_t start, idx_t end);
 

--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -97,25 +97,23 @@ static void LoadInternal(DatabaseInstance &db) {
 	config.AddExtensionOption("pg_connection_limit", "The maximum amount of concurrent Postgres connections",
 	                          LogicalType::UBIGINT, Value::UBIGINT(PostgresConnectionPool::DEFAULT_MAX_CONNECTIONS),
 	                          SetPostgresConnectionLimit);
-	config.AddExtensionOption("pg_array_as_varchar",
-	                          "Read Postgres arrays as varchar - enables reading mixed dimensional arrays",
-	                          LogicalType::BOOLEAN, Value::BOOLEAN(false), PostgresClearCacheFunction::ClearCacheOnSetting);
-	config.AddExtensionOption("pg_connection_cache",
-							  "Whether or not to use the connection cache", LogicalType::BOOLEAN,
-							  Value::BOOLEAN(true), PostgresConnectionPool::PostgresSetConnectionCache);
+	config.AddExtensionOption(
+	    "pg_array_as_varchar", "Read Postgres arrays as varchar - enables reading mixed dimensional arrays",
+	    LogicalType::BOOLEAN, Value::BOOLEAN(false), PostgresClearCacheFunction::ClearCacheOnSetting);
+	config.AddExtensionOption("pg_connection_cache", "Whether or not to use the connection cache", LogicalType::BOOLEAN,
+	                          Value::BOOLEAN(true), PostgresConnectionPool::PostgresSetConnectionCache);
 	config.AddExtensionOption("pg_experimental_filter_pushdown",
 	                          "Whether or not to use filter pushdown (currently experimental)", LogicalType::BOOLEAN,
 	                          Value::BOOLEAN(false));
 	config.AddExtensionOption("pg_debug_show_queries", "DEBUG SETTING: print all queries sent to Postgres to stdout",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(false), SetPostgresDebugQueryPrint);
 
-
 	OptimizerExtension postgres_optimizer;
 	postgres_optimizer.optimize_function = PostgresOptimizer::Optimize;
 	config.optimizer_extensions.push_back(std::move(postgres_optimizer));
 
 	config.extension_callbacks.push_back(make_uniq<PostgresExtensionCallback>());
-	for(auto &connection : ConnectionManager::Get(db).GetConnectionList()) {
+	for (auto &connection : ConnectionManager::Get(db).GetConnectionList()) {
 		connection->registered_state.insert(make_pair("postgres_extension", make_shared<PostgresExtensionState>()));
 	}
 }

--- a/src/postgres_scanner.cpp
+++ b/src/postgres_scanner.cpp
@@ -481,12 +481,13 @@ unique_ptr<NodeStatistics> PostgresScanCardinality(ClientContext &context, const
 }
 
 double PostgresScanProgress(ClientContext &context, const FunctionData *bind_data_p,
-											const GlobalTableFunctionState *global_state) {
+                            const GlobalTableFunctionState *global_state) {
 	auto &bind_data = bind_data_p->Cast<PostgresBindData>();
 	auto &gstate = global_state->Cast<PostgresGlobalState>();
 
 	lock_guard<mutex> parallel_lock(gstate.lock);
-	double progress = 100 * double(gstate.page_idx) / double(bind_data.pages_approx);;
+	double progress = 100 * double(gstate.page_idx) / double(bind_data.pages_approx);
+	;
 	return MinValue<double>(100, progress);
 }
 

--- a/src/storage/postgres_catalog_set.cpp
+++ b/src/storage/postgres_catalog_set.cpp
@@ -105,8 +105,8 @@ void PostgresCatalogSet::ClearEntries() {
 	is_loaded = false;
 }
 
-PostgresInSchemaSet::PostgresInSchemaSet(PostgresSchemaEntry &schema, bool is_loaded) :
-	PostgresCatalogSet(schema.ParentCatalog(), is_loaded), schema(schema) {
+PostgresInSchemaSet::PostgresInSchemaSet(PostgresSchemaEntry &schema, bool is_loaded)
+    : PostgresCatalogSet(schema.ParentCatalog(), is_loaded), schema(schema) {
 }
 
 optional_ptr<CatalogEntry> PostgresInSchemaSet::CreateEntry(unique_ptr<CatalogEntry> entry) {

--- a/src/storage/postgres_index.cpp
+++ b/src/storage/postgres_index.cpp
@@ -18,23 +18,25 @@ SourceResultType PostgresCreateIndex::GetData(ExecutionContext &context, DataChu
                                               OperatorSourceInput &input) const {
 	auto &catalog = table.catalog;
 	auto &schema = table.schema;
-	auto existing = schema.GetEntry(catalog.GetCatalogTransaction(context.client), CatalogType::INDEX_ENTRY, info->index_name);
+	auto existing =
+	    schema.GetEntry(catalog.GetCatalogTransaction(context.client), CatalogType::INDEX_ENTRY, info->index_name);
 	if (existing) {
-		switch(info->on_conflict) {
-			case OnCreateConflict::IGNORE_ON_CONFLICT:
-				return SourceResultType::FINISHED;
-			case OnCreateConflict::ERROR_ON_CONFLICT:
-				throw BinderException("Index with name \"%s\" already exists in schema \"%s\"", info->index_name, table.schema.name);
-			case OnCreateConflict::REPLACE_ON_CONFLICT: {
-				DropInfo drop_info;
-				drop_info.type = CatalogType::INDEX_ENTRY;
-				drop_info.schema = info->schema;
-				drop_info.name = info->index_name;
-				schema.DropEntry(context.client, drop_info);
-				break;
-			}
-			default:
-				throw InternalException("Unsupported on create conflict");
+		switch (info->on_conflict) {
+		case OnCreateConflict::IGNORE_ON_CONFLICT:
+			return SourceResultType::FINISHED;
+		case OnCreateConflict::ERROR_ON_CONFLICT:
+			throw BinderException("Index with name \"%s\" already exists in schema \"%s\"", info->index_name,
+			                      table.schema.name);
+		case OnCreateConflict::REPLACE_ON_CONFLICT: {
+			DropInfo drop_info;
+			drop_info.type = CatalogType::INDEX_ENTRY;
+			drop_info.schema = info->schema;
+			drop_info.name = info->index_name;
+			schema.DropEntry(context.client, drop_info);
+			break;
+		}
+		default:
+			throw InternalException("Unsupported on create conflict");
 		}
 	}
 	schema.CreateIndex(context.client, *info, table);

--- a/src/storage/postgres_optimizer.cpp
+++ b/src/storage/postgres_optimizer.cpp
@@ -29,12 +29,13 @@ void GatherPostgresScans(LogicalOperator &op, PostgresOperators &result) {
 		result.scans[*catalog].push_back(get);
 	}
 	// recurse into children
-	for(auto &child : op.children) {
+	for (auto &child : op.children) {
 		GatherPostgresScans(*child, result);
 	}
 }
 
-void PostgresOptimizer::Optimize(ClientContext &context, OptimizerExtensionInfo *info, unique_ptr<LogicalOperator> &plan) {
+void PostgresOptimizer::Optimize(ClientContext &context, OptimizerExtensionInfo *info,
+                                 unique_ptr<LogicalOperator> &plan) {
 	// look at the query plan and check if we can enable streaming query scans
 	PostgresOperators operators;
 	GatherPostgresScans(*plan, operators);
@@ -42,10 +43,10 @@ void PostgresOptimizer::Optimize(ClientContext &context, OptimizerExtensionInfo 
 		// no scans
 		return;
 	}
-	for(auto &entry : operators.scans) {
+	for (auto &entry : operators.scans) {
 		auto &catalog = entry.first;
 		auto multiple_scans = entry.second.size() > 1;
-		for(auto &scan : entry.second) {
+		for (auto &scan : entry.second) {
 			auto &bind_data = scan.get().bind_data->Cast<PostgresBindData>();
 			// if there is a single scan in the plan we can always stream using the main thread
 			// if there is more than one scan we either (1) need to materialize, or (2) cannot use the main thread

--- a/src/storage/postgres_schema_entry.cpp
+++ b/src/storage/postgres_schema_entry.cpp
@@ -17,12 +17,12 @@ PostgresSchemaEntry::PostgresSchemaEntry(Catalog &catalog, CreateSchemaInfo &inf
     : SchemaCatalogEntry(catalog, info), tables(*this), indexes(*this), types(*this) {
 }
 
-PostgresSchemaEntry::PostgresSchemaEntry(Catalog &catalog, CreateSchemaInfo &info, unique_ptr<PostgresResultSlice> tables,
-                                         unique_ptr<PostgresResultSlice> enums,
+PostgresSchemaEntry::PostgresSchemaEntry(Catalog &catalog, CreateSchemaInfo &info,
+                                         unique_ptr<PostgresResultSlice> tables, unique_ptr<PostgresResultSlice> enums,
                                          unique_ptr<PostgresResultSlice> composite_types,
                                          unique_ptr<PostgresResultSlice> indexes)
-    : SchemaCatalogEntry(catalog, info), tables(*this, std::move(tables)),
-      indexes(*this, std::move(indexes)), types(*this, std::move(enums), std::move(composite_types)) {
+    : SchemaCatalogEntry(catalog, info), tables(*this, std::move(tables)), indexes(*this, std::move(indexes)),
+      types(*this, std::move(enums), std::move(composite_types)) {
 }
 
 bool PostgresSchemaEntry::SchemaIsInternal(const string &name) {

--- a/src/storage/postgres_schema_set.cpp
+++ b/src/storage/postgres_schema_set.cpp
@@ -61,12 +61,11 @@ void PostgresSchemaSet::LoadEntries(ClientContext &context) {
 	for (idx_t row = 0; row < rows; row++) {
 		auto oid = result->GetInt64(row, 0);
 		auto schema_name = result->GetString(row, 1);
-                CreateSchemaInfo info;
-                info.schema = schema_name;
-                info.internal = PostgresSchemaEntry::SchemaIsInternal(schema_name);
-		auto schema =
-		    make_uniq<PostgresSchemaEntry>(catalog, info, std::move(tables[row]), std::move(enums[row]),
-		                                   std::move(composite_types[row]), std::move(indexes[row]));
+		CreateSchemaInfo info;
+		info.schema = schema_name;
+		info.internal = PostgresSchemaEntry::SchemaIsInternal(schema_name);
+		auto schema = make_uniq<PostgresSchemaEntry>(catalog, info, std::move(tables[row]), std::move(enums[row]),
+		                                             std::move(composite_types[row]), std::move(indexes[row]));
 		CreateEntry(std::move(schema));
 	}
 }
@@ -76,8 +75,8 @@ optional_ptr<CatalogEntry> PostgresSchemaSet::CreateSchema(ClientContext &contex
 
 	string create_sql = "CREATE SCHEMA " + KeywordHelper::WriteQuoted(info.schema, '"');
 	transaction.Query(create_sql);
-        auto info_copy = info.Copy();
-        info.internal = PostgresSchemaEntry::SchemaIsInternal(info_copy->schema);
+	auto info_copy = info.Copy();
+	info.internal = PostgresSchemaEntry::SchemaIsInternal(info_copy->schema);
 	auto schema_entry = make_uniq<PostgresSchemaEntry>(catalog, info_copy->Cast<CreateSchemaInfo>());
 	return CreateEntry(std::move(schema_entry));
 }

--- a/src/storage/postgres_table_set.cpp
+++ b/src/storage/postgres_table_set.cpp
@@ -107,7 +107,7 @@ void PostgresTableSet::AddConstraint(PostgresResult &result, idx_t row, Postgres
 void PostgresTableSet::AddColumnOrConstraint(optional_ptr<PostgresTransaction> transaction,
                                              optional_ptr<PostgresSchemaEntry> schema, PostgresResult &result,
                                              idx_t row, PostgresTableInfo &table_info) {
-	if (result.IsNull(row, 2)) {
+	if (result.IsNull(row, 3)) {
 		// constraint
 		AddConstraint(result, row, table_info);
 	} else {
@@ -167,7 +167,7 @@ unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(PostgresTransaction
 	for (idx_t row = 0; row < rows; row++) {
 		AddColumnOrConstraint(&transaction, &schema, *result, row, *table_info);
 	}
-	table_info->approx_num_pages = result->GetInt64(0, 0);
+	table_info->approx_num_pages = result->GetInt64(0, 2);
 	return table_info;
 }
 
@@ -183,7 +183,7 @@ unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(PostgresConnection 
 	for (idx_t row = 0; row < rows; row++) {
 		AddColumnOrConstraint(nullptr, nullptr, *result, row, *table_info);
 	}
-	table_info->approx_num_pages = result->GetInt64(0, 0);
+	table_info->approx_num_pages = result->GetInt64(0, 2);
 	return table_info;
 }
 

--- a/src/storage/postgres_table_set.cpp
+++ b/src/storage/postgres_table_set.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/parser/constraints/list.hpp"
 #include "storage/postgres_schema_entry.hpp"
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "postgres_conversion.hpp"
 
 namespace duckdb {
@@ -18,28 +19,48 @@ PostgresTableSet::PostgresTableSet(PostgresSchemaEntry &schema, unique_ptr<Postg
     : PostgresInSchemaSet(schema, !table_result_p), table_result(std::move(table_result_p)) {
 }
 
-string PostgresTableSet::GetInitializeQuery() {
-	return R"(
-SELECT pg_namespace.oid, relname, relpages, attname,
-    pg_type.typname type_name, atttypmod type_modifier, pg_attribute.attndims ndim
+string PostgresTableSet::GetInitializeQuery(const string &schema, const string &table) {
+	string base_query = R"(
+SELECT pg_namespace.oid AS namespace_id, relname, relpages, attname,
+    pg_type.typname type_name, atttypmod type_modifier, pg_attribute.attndims ndim,
+    attnum, pg_attribute.attnotnull AS notnull, NULL constraint_id,
+    NULL constraint_type, NULL constraint_key
 FROM pg_class
 JOIN pg_namespace ON relnamespace = pg_namespace.oid
 JOIN pg_attribute ON pg_class.oid=pg_attribute.attrelid
 JOIN pg_type ON atttypid=pg_type.oid
-WHERE attnum > 0 AND relkind IN ('r', 'v', 'm', 'f', 'p')
-ORDER BY pg_namespace.oid, relname, attnum;
+WHERE attnum > 0 AND relkind IN ('r', 'v', 'm', 'f', 'p') ${CONDITION}
+UNION ALL
+SELECT pg_namespace.oid AS namespace_id, relname, NULL relpages, NULL attname, NULL type_name,
+    NULL type_modifier, NULL ndim, NULL attnum, NULL AS notnull,
+    pg_constraint.oid AS constraint_id, contype AS constraint_type,
+    conkey AS constraint_key
+FROM pg_class
+JOIN pg_namespace ON relnamespace = pg_namespace.oid
+JOIN pg_constraint ON (pg_class.oid=pg_constraint.conrelid)
+WHERE contype IN ('p', 'u') ${CONDITION}
+ORDER BY namespace_id, relname, attnum, constraint_id;
 )";
+	string condition;
+	if (!schema.empty()) {
+		condition += "AND pg_namespace.nspname=" + KeywordHelper::WriteQuoted(schema);
+	}
+	if (!table.empty()) {
+		condition += "AND relname=" + KeywordHelper::WriteQuoted(table);
+	}
+	return StringUtil::Replace(base_query, "${CONDITION}", condition);
 }
 
 void PostgresTableSet::AddColumn(optional_ptr<PostgresTransaction> transaction,
                                  optional_ptr<PostgresSchemaEntry> schema, PostgresResult &result, idx_t row,
-                                 PostgresTableInfo &table_info, idx_t column_offset) {
+                                 PostgresTableInfo &table_info) {
 	PostgresTypeData type_info;
-	idx_t column_index = column_offset;
+	idx_t column_index = 3;
 	auto column_name = result.GetString(row, column_index);
 	type_info.type_name = result.GetString(row, column_index + 1);
 	type_info.type_modifier = result.GetInt64(row, column_index + 2);
 	type_info.array_dimensions = result.GetInt64(row, column_index + 3);
+	bool is_not_null = result.GetBool(row, column_index + 5);
 	string default_value;
 
 	PostgresType postgres_type;
@@ -55,7 +76,43 @@ void PostgresTableSet::AddColumn(optional_ptr<PostgresTransaction> transaction,
 		column.SetDefaultValue(std::move(expressions[0]));
 	}
 	auto &create_info = *table_info.create_info;
+	if (is_not_null) {
+		create_info.constraints.push_back(
+		    make_uniq<NotNullConstraint>(LogicalIndex(create_info.columns.PhysicalColumnCount())));
+	}
 	create_info.columns.AddColumn(std::move(column));
+}
+
+void PostgresTableSet::AddConstraint(PostgresResult &result, idx_t row, PostgresTableInfo &table_info) {
+	idx_t column_index = 9;
+	auto constraint_type = result.GetString(row, column_index + 1);
+	auto constraint_key = result.GetString(row, column_index + 2);
+	if (constraint_key.empty() || constraint_key.front() != '{' || constraint_key.back() != '}') {
+		// invalid constraint key
+		D_ASSERT(0);
+		return;
+	}
+
+	auto &create_info = *table_info.create_info;
+	auto splits = StringUtil::Split(constraint_key.substr(1, constraint_key.size() - 2), ",");
+	vector<string> columns;
+	for (auto &split : splits) {
+		auto index = std::stoull(split);
+		columns.push_back(create_info.columns.GetColumn(LogicalIndex(index - 1)).Name());
+	}
+
+	create_info.constraints.push_back(make_uniq<UniqueConstraint>(std::move(columns), constraint_type == "p"));
+}
+
+void PostgresTableSet::AddColumnOrConstraint(optional_ptr<PostgresTransaction> transaction,
+                                             optional_ptr<PostgresSchemaEntry> schema, PostgresResult &result,
+                                             idx_t row, PostgresTableInfo &table_info) {
+	if (result.IsNull(row, 2)) {
+		// constraint
+		AddConstraint(result, row, table_info);
+	} else {
+		AddColumn(transaction, schema, result, row, table_info);
+	}
 }
 
 void PostgresTableSet::CreateEntries(PostgresTransaction &transaction, PostgresResult &result, idx_t start, idx_t end) {
@@ -64,15 +121,15 @@ void PostgresTableSet::CreateEntries(PostgresTransaction &transaction, PostgresR
 
 	for (idx_t row = start; row < end; row++) {
 		auto table_name = result.GetString(row, 1);
-		auto approx_num_pages = result.GetInt64(row, 2);
 		if (!info || info->GetTableName() != table_name) {
 			if (info) {
 				tables.push_back(std::move(info));
 			}
+			auto approx_num_pages = result.IsNull(row, 2) ? 0 : result.GetInt64(row, 2);
 			info = make_uniq<PostgresTableInfo>(schema, table_name);
 			info->approx_num_pages = approx_num_pages;
 		}
-		AddColumn(&transaction, &schema, result, row, *info, 3);
+		AddColumnOrConstraint(&transaction, &schema, result, row, *info);
 	}
 	if (info) {
 		tables.push_back(std::move(info));
@@ -89,17 +146,7 @@ void PostgresTableSet::LoadEntries(ClientContext &context) {
 		CreateEntries(transaction, table_result->GetResult(), table_result->start, table_result->end);
 		table_result.reset();
 	} else {
-		auto query = StringUtil::Replace(R"(
-	SELECT 0, relname, relpages, attname,
-		pg_type.typname type_name, atttypmod type_modifier, pg_attribute.attndims ndim
-	FROM pg_class
-	JOIN pg_namespace ON relnamespace = pg_namespace.oid
-	JOIN pg_attribute ON pg_class.oid=pg_attribute.attrelid
-	JOIN pg_type ON atttypid=pg_type.oid
-	WHERE pg_namespace.nspname=${SCHEMA_NAME} AND attnum > 0 AND relkind IN ('r', 'v', 'm', 'f', 'p')
-	ORDER BY relname, attnum;
-	)",
-		                                 "${SCHEMA_NAME}", KeywordHelper::WriteQuoted(schema.name));
+		auto query = GetInitializeQuery(schema.name);
 
 		auto result = transaction.Query(query);
 		auto rows = result->Count();
@@ -108,24 +155,9 @@ void PostgresTableSet::LoadEntries(ClientContext &context) {
 	}
 }
 
-string GetTableInfoQuery(const string &schema_name, const string &table_name) {
-	return StringUtil::Replace(StringUtil::Replace(R"(
-SELECT relpages, attname,
-    pg_type.typname type_name, atttypmod type_modifier, pg_attribute.attndims ndim
-FROM pg_class
-JOIN pg_namespace ON relnamespace = pg_namespace.oid
-JOIN pg_attribute ON pg_class.oid=pg_attribute.attrelid
-JOIN pg_type ON atttypid=pg_type.oid
-WHERE pg_namespace.nspname=${SCHEMA_NAME} AND relname=${TABLE_NAME} AND attnum > 0 AND relkind IN ('r', 'v', 'm', 'f', 'p')
-ORDER BY relname, attnum;
-)",
-	                                               "${SCHEMA_NAME}", KeywordHelper::WriteQuoted(schema_name)),
-	                           "${TABLE_NAME}", KeywordHelper::WriteQuoted(table_name));
-}
-
 unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(PostgresTransaction &transaction,
                                                              PostgresSchemaEntry &schema, const string &table_name) {
-	auto query = GetTableInfoQuery(schema.name, table_name);
+	auto query = PostgresTableSet::GetInitializeQuery(schema.name, table_name);
 	auto result = transaction.Query(query);
 	auto rows = result->Count();
 	if (rows == 0) {
@@ -133,7 +165,7 @@ unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(PostgresTransaction
 	}
 	auto table_info = make_uniq<PostgresTableInfo>(schema, table_name);
 	for (idx_t row = 0; row < rows; row++) {
-		AddColumn(&transaction, &schema, *result, row, *table_info, 1);
+		AddColumnOrConstraint(&transaction, &schema, *result, row, *table_info);
 	}
 	table_info->approx_num_pages = result->GetInt64(0, 0);
 	return table_info;
@@ -141,7 +173,7 @@ unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(PostgresTransaction
 
 unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(PostgresConnection &connection, const string &schema_name,
                                                              const string &table_name) {
-	auto query = GetTableInfoQuery(schema_name, table_name);
+	auto query = PostgresTableSet::GetInitializeQuery(schema_name, table_name);
 	auto result = connection.Query(query);
 	auto rows = result->Count();
 	if (rows == 0) {
@@ -149,7 +181,7 @@ unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(PostgresConnection 
 	}
 	auto table_info = make_uniq<PostgresTableInfo>(schema_name, table_name);
 	for (idx_t row = 0; row < rows; row++) {
-		AddColumn(nullptr, nullptr, *result, row, *table_info, 1);
+		AddColumnOrConstraint(nullptr, nullptr, *result, row, *table_info);
 	}
 	table_info->approx_num_pages = result->GetInt64(0, 0);
 	return table_info;

--- a/test/other.sql
+++ b/test/other.sql
@@ -159,3 +159,7 @@ INSERT INTO chars_array VALUES (ARRAY['hello', 'world', 'maxlength1', 'hello    
 -- varchar with length limit
 CREATE TABLE varchars_fixed_len(c VARCHAR(10));
 INSERT INTO varchars_fixed_len VALUES ('hello'), ('world'), ('maxlength1'), ('hello     '), ('     '), (NULL);
+
+-- tables with constraints
+create table tbl_with_constraints(pk int primary key, c1 int not null, c2 int, c3 int not null);
+create table tbl_with_more_constraints(pk1 int, pk2 int, fk1 int references tbl_with_constraints(pk), primary key (pk1, pk2));

--- a/test/other.sql
+++ b/test/other.sql
@@ -163,3 +163,4 @@ INSERT INTO varchars_fixed_len VALUES ('hello'), ('world'), ('maxlength1'), ('he
 -- tables with constraints
 create table tbl_with_constraints(pk int primary key, c1 int not null, c2 int, c3 int not null);
 create table tbl_with_more_constraints(pk1 int, pk2 int, fk1 int references tbl_with_constraints(pk), primary key (pk1, pk2));
+create table tbl_with_unique_constraints(pk int unique, c1 int not null, c2 int, c3 int not null, unique(c2, c3));

--- a/test/sql/storage/attach_existing_constraints.test
+++ b/test/sql/storage/attach_existing_constraints.test
@@ -1,0 +1,39 @@
+# name: test/sql/storage/attach_existing_constraints.test
+# description: Test existing constraints
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, READ_ONLY)
+
+statement ok
+USE s
+
+query IIII
+SELECT column_name, column_type, "null", key FROM (DESCRIBE tbl_with_constraints)
+----
+pk	INTEGER	NO	PRI
+c1	INTEGER	NO	NULL
+c2	INTEGER	YES	NULL
+c3	INTEGER	NO	NULL
+
+query IIII
+SELECT column_name, column_type, "null", key FROM (DESCRIBE tbl_with_more_constraints)
+----
+pk1	INTEGER	NO	PRI
+pk2	INTEGER	NO	PRI
+fk1	INTEGER	YES	NULL
+
+query IIII
+SELECT column_name, column_type, "null", key FROM (DESCRIBE tbl_with_unique_constraints)
+----
+pk	INTEGER	YES	UNI
+c1	INTEGER	NO	NULL
+c2	INTEGER	YES	UNI
+c3	INTEGER	NO	UNI


### PR DESCRIPTION
Fix #190 

When querying table information from postgres, also query the `pg_constraint` table to find unique/primary key constraints.