### PR TITLE
Fix #202 - correctly escape backslashes in Postgres text copy

### DIFF
--- a/src/include/postgres_text_writer.hpp
+++ b/src/include/postgres_text_writer.hpp
@@ -21,34 +21,42 @@ public:
 		stream.WriteData(const_data_ptr_cast("\b"), 1);
 	}
 
+	void WriteCharInternal(char c) {
+		stream.WriteData(const_data_ptr_cast(&c), 1);
+	}
+
 	void WriteChar(char c) {
 		switch (c) {
 		case '\n':
-			WriteChar('\\');
-			WriteChar('n');
+			WriteCharInternal('\\');
+			WriteCharInternal('n');
 			break;
 		case '\r':
-			WriteChar('\\');
-			WriteChar('r');
+			WriteCharInternal('\\');
+			WriteCharInternal('r');
 			break;
 		case '\b':
-			WriteChar('\\');
-			WriteChar('b');
+			WriteCharInternal('\\');
+			WriteCharInternal('b');
 			break;
 		case '\f':
-			WriteChar('\\');
-			WriteChar('f');
+			WriteCharInternal('\\');
+			WriteCharInternal('f');
 			break;
 		case '\t':
-			WriteChar('\\');
-			WriteChar('t');
+			WriteCharInternal('\\');
+			WriteCharInternal('t');
 			break;
 		case '\v':
-			WriteChar('\\');
-			WriteChar('v');
+			WriteCharInternal('\\');
+			WriteCharInternal('v');
+			break;
+		case '\\':
+			WriteCharInternal('\\');
+			WriteCharInternal('\\');
 			break;
 		default:
-			stream.WriteData(const_data_ptr_cast(&c), 1);
+			WriteCharInternal(c);
 			break;
 		}
 	}

--- a/src/include/postgres_text_writer.hpp
+++ b/src/include/postgres_text_writer.hpp
@@ -55,6 +55,10 @@ public:
 			WriteCharInternal('\\');
 			WriteCharInternal('\\');
 			break;
+		case '"':
+			WriteCharInternal('\\');
+			WriteCharInternal('"');
+			break;
 		default:
 			WriteCharInternal(c);
 			break;

--- a/src/postgres_copy_to.cpp
+++ b/src/postgres_copy_to.cpp
@@ -197,7 +197,7 @@ void CastBlobToPostgres(ClientContext &context, Vector &input, Vector &result, i
 			continue;
 		}
 		const char *HEX_STRING = "0123456789ABCDEF";
-		string blob_str = "\\\\x";
+		string blob_str = "\\x";
 		auto blob_data = const_data_ptr_cast(input_data[r].GetData());
 		auto blob_size = input_data[r].GetSize();
 		for (idx_t c = 0; c < blob_size; c++) {

--- a/src/postgres_copy_to.cpp
+++ b/src/postgres_copy_to.cpp
@@ -122,11 +122,11 @@ void CastListToPostgresArray(ClientContext &context, Vector &input, Vector &varc
 				result += "NULL";
 			} else {
 				if (requires_quotes) {
-					result += StringUtil::Repeat("\\\"", depth);
+					result += StringUtil::Repeat("\"", depth);
 				}
 				result += child_entries[child_idx].GetString();
 				if (requires_quotes) {
-					result += StringUtil::Repeat("\\\"", depth);
+					result += StringUtil::Repeat("\"", depth);
 				}
 			}
 		}
@@ -175,11 +175,11 @@ void CastStructToPostgres(ClientContext &context, Vector &input, Vector &varchar
 			} else {
 				bool requires_quotes = child_requires_quotes[c];
 				if (requires_quotes) {
-					result += StringUtil::Repeat("\\\"", depth);
+					result += StringUtil::Repeat("\"", depth);
 				}
 				result += FlatVector::GetData<string_t>(child_varchar_vectors[c])[r].GetString();
 				if (requires_quotes) {
-					result += StringUtil::Repeat("\\\"", depth);
+					result += StringUtil::Repeat("\"", depth);
 				}
 			}
 		}

--- a/test/sql/storage/attach_backslash.test
+++ b/test/sql/storage/attach_backslash.test
@@ -1,0 +1,28 @@
+# name: test/sql/storage/attach_backslash.test
+# description: Test inserting backslashes using the text copy
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+SET pg_use_binary_copy=false;
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s1 (TYPE POSTGRES)
+
+statement ok
+CREATE OR REPLACE TABLE s1.varchar_data(v VARCHAR);
+
+statement ok
+INSERT INTO s1.varchar_data VALUES ('\42\');
+
+query I
+SELECT * FROM s1.varchar_data
+----
+\42\
+

--- a/test/sql/storage/attach_backslash.test
+++ b/test/sql/storage/attach_backslash.test
@@ -19,10 +19,11 @@ statement ok
 CREATE OR REPLACE TABLE s1.varchar_data(v VARCHAR);
 
 statement ok
-INSERT INTO s1.varchar_data VALUES ('\42\');
+INSERT INTO s1.varchar_data VALUES ('\42\'), ('"quoted value \ with backslashes ''\"');
 
 query I
 SELECT * FROM s1.varchar_data
 ----
 \42\
+"quoted value \ with backslashes '\"
 


### PR DESCRIPTION
Fix #202 