### PR TITLE
Fix #206 - use text copy when the oid we generate does not match the internal oid for the type

### DIFF
--- a/src/storage/postgres_table_entry.cpp
+++ b/src/storage/postgres_table_entry.cpp
@@ -74,6 +74,9 @@ static bool CopyRequiresText(const LogicalType &type, const PostgresType &pg_typ
 	if (pg_type.info != PostgresTypeAnnotation::STANDARD) {
 		return true;
 	}
+	if (pg_type.oid != PostgresUtils::ToPostgresOid(type)) {
+		return true;
+	}
 	switch (type.id()) {
 	case LogicalTypeId::LIST: {
 		D_ASSERT(pg_type.children.size() == 1);

--- a/src/storage/postgres_table_entry.cpp
+++ b/src/storage/postgres_table_entry.cpp
@@ -74,15 +74,17 @@ static bool CopyRequiresText(const LogicalType &type, const PostgresType &pg_typ
 	if (pg_type.info != PostgresTypeAnnotation::STANDARD) {
 		return true;
 	}
-	if (pg_type.oid != PostgresUtils::ToPostgresOid(type)) {
-		return true;
-	}
 	switch (type.id()) {
 	case LogicalTypeId::LIST: {
 		D_ASSERT(pg_type.children.size() == 1);
 		auto &child_type = ListType::GetChildType(type);
-		if (child_type.id() != LogicalTypeId::LIST && !PostgresUtils::SupportedPostgresOid(child_type)) {
-			return true;
+		if (child_type.id() != LogicalTypeId::LIST) {
+			if (!PostgresUtils::SupportedPostgresOid(child_type)) {
+				return true;
+			}
+			if (pg_type.children[0].oid != PostgresUtils::ToPostgresOid(child_type)) {
+				return true;
+			}
 		}
 		if (CopyRequiresText(child_type, pg_type.children[0])) {
 			return true;

--- a/test/sql/storage/attach_text_array.test
+++ b/test/sql/storage/attach_text_array.test
@@ -1,0 +1,27 @@
+# name: test/sql/storage/attach_text_array.test
+# description: Insert into TEXT arrays
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS simple (TYPE POSTGRES)
+
+statement ok
+DROP TABLE IF EXISTS simple.text_array_tbl
+
+statement ok
+call postgres_execute('simple', 'create table text_array_tbl(foo text[])');
+
+statement ok
+insert into simple.text_array_tbl values([]::text[]);
+
+query I
+SELECT * FROM simple.text_array_tbl
+----
+[]


### PR DESCRIPTION
Fixes #206 