### PR TITLE
Allow Postgres credentials to be managed using the SecretManager

### DIFF
--- a/src/postgres_storage.cpp
+++ b/src/postgres_storage.cpp
@@ -37,36 +37,61 @@ string AddConnectionOption(const KeyValueSecret &kv_secret, const string &name) 
 	return result;
 }
 
+unique_ptr<SecretEntry> GetSecret(ClientContext &context, const string &secret_name) {
+	auto &secret_manager = SecretManager::Get(context);
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+	// FIXME: this should be adjusted once the `GetSecretByName` API supports this use case
+	auto secret_entry = secret_manager.GetSecretByName(transaction, secret_name, "memory");
+	if (secret_entry) {
+		return secret_entry;
+	}
+	secret_entry = secret_manager.GetSecretByName(transaction, secret_name, "local_file");
+	if (secret_entry) {
+		return secret_entry;
+	}
+	return nullptr;
+}
+
 static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, ClientContext &context,
                                           AttachedDatabase &db, const string &name, AttachInfo &info,
                                           AccessMode access_mode) {
 	string connection_string = info.path;
+
+	string secret_name;
 	for(auto &entry : info.options) {
 		auto lower_name = StringUtil::Lower(entry.first);
 		if (lower_name == "type" || lower_name == "read_only") {
 			// already handled
 		} else if (lower_name == "secret") {
-			auto &secret_manager = SecretManager::Get(context);
-			auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
-			auto secret_name = entry.second.ToString();
-			auto secret_entry = secret_manager.GetSecretByName(transaction, secret_name);
-			if (!secret_entry) {
-				throw BinderException("Secret with name \"%s\" not found", secret_name);
-			}
-			// secret found - read
-			const auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*secret_entry->secret);
-			string new_connection_info;
-
-			new_connection_info += AddConnectionOption(kv_secret, "user");
-			new_connection_info += AddConnectionOption(kv_secret, "password");
-			new_connection_info += AddConnectionOption(kv_secret, "host");
-			new_connection_info += AddConnectionOption(kv_secret, "port");
-			new_connection_info += AddConnectionOption(kv_secret, "dbname");
-
-			connection_string = new_connection_info + connection_string;
+			secret_name = entry.second.ToString();
 		} else {
 			throw BinderException("Unrecognized option for Postgres attach: %s", entry.first);
 		}
+	}
+
+	// if no secret is specified we default to the unnamed postgres secret, if it exists
+	bool explicit_secret = !secret_name.empty();
+	if (!explicit_secret) {
+		// look up settings from the default unnamed postgres secret if none is provided
+		secret_name = "__default_postgres";
+	}
+
+	auto secret_entry = GetSecret(context, secret_name);
+	if (secret_entry) {
+		// secret found - read data
+		const auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*secret_entry->secret);
+		string new_connection_info;
+
+		new_connection_info += AddConnectionOption(kv_secret, "user");
+		new_connection_info += AddConnectionOption(kv_secret, "password");
+		new_connection_info += AddConnectionOption(kv_secret, "host");
+		new_connection_info += AddConnectionOption(kv_secret, "port");
+		new_connection_info += AddConnectionOption(kv_secret, "dbname");
+
+		connection_string = new_connection_info + connection_string;
+	} else if (explicit_secret) {
+		// secret not found and one was explicitly provided - throw an error
+		throw BinderException("Secret with name \"%s\" not found", secret_name);
 	}
 	return make_uniq<PostgresCatalog>(db, connection_string, access_mode);
 }

--- a/src/postgres_storage.cpp
+++ b/src/postgres_storage.cpp
@@ -4,13 +4,71 @@
 #include "storage/postgres_catalog.hpp"
 #include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "storage/postgres_transaction_manager.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
 
 namespace duckdb {
+
+string EscapeConnectionString(const string &input) {
+	string result = "'";
+	for(auto c : input) {
+		if (c == '\\') {
+			result += "\\\\";
+		} else if (c == '\'') {
+			result += "\\'";
+		} else {
+			result += c;
+		}
+	}
+	result +=  "'";
+	return result;
+}
+
+string AddConnectionOption(const KeyValueSecret &kv_secret, const string &name) {
+	Value input_val = kv_secret.TryGetValue(name);
+	if (input_val.IsNull()) {
+		// not provided
+		return string();
+	}
+	string result;
+	result += name;
+	result += "=";
+	result += EscapeConnectionString(input_val.ToString());
+	result += " ";
+	return result;
+}
 
 static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, ClientContext &context,
                                           AttachedDatabase &db, const string &name, AttachInfo &info,
                                           AccessMode access_mode) {
-	return make_uniq<PostgresCatalog>(db, info.path, access_mode);
+	string connection_string = info.path;
+	for(auto &entry : info.options) {
+		auto lower_name = StringUtil::Lower(entry.first);
+		if (lower_name == "type" || lower_name == "read_only") {
+			// already handled
+		} else if (lower_name == "secret") {
+			auto &secret_manager = SecretManager::Get(context);
+			auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+			auto secret_name = entry.second.ToString();
+			auto secret_entry = secret_manager.GetSecretByName(transaction, secret_name);
+			if (!secret_entry) {
+				throw BinderException("Secret with name \"%s\" not found", secret_name);
+			}
+			// secret found - read
+			const auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*secret_entry->secret);
+			string new_connection_info;
+
+			new_connection_info += AddConnectionOption(kv_secret, "user");
+			new_connection_info += AddConnectionOption(kv_secret, "password");
+			new_connection_info += AddConnectionOption(kv_secret, "host");
+			new_connection_info += AddConnectionOption(kv_secret, "port");
+			new_connection_info += AddConnectionOption(kv_secret, "dbname");
+
+			connection_string = new_connection_info + connection_string;
+		} else {
+			throw BinderException("Unrecognized option for Postgres attach: %s", entry.first);
+		}
+	}
+	return make_uniq<PostgresCatalog>(db, connection_string, access_mode);
 }
 
 static unique_ptr<TransactionManager> PostgresCreateTransactionManager(StorageExtensionInfo *storage_info,

--- a/src/postgres_storage.cpp
+++ b/src/postgres_storage.cpp
@@ -10,7 +10,7 @@ namespace duckdb {
 
 string EscapeConnectionString(const string &input) {
 	string result = "'";
-	for(auto c : input) {
+	for (auto c : input) {
 		if (c == '\\') {
 			result += "\\\\";
 		} else if (c == '\'') {
@@ -19,7 +19,7 @@ string EscapeConnectionString(const string &input) {
 			result += c;
 		}
 	}
-	result +=  "'";
+	result += "'";
 	return result;
 }
 
@@ -58,7 +58,7 @@ static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, Cl
 	string connection_string = info.path;
 
 	string secret_name;
-	for(auto &entry : info.options) {
+	for (auto &entry : info.options) {
 		auto lower_name = StringUtil::Lower(entry.first);
 		if (lower_name == "type" || lower_name == "read_only") {
 			// already handled

--- a/test/sql/storage/attach_secret.test
+++ b/test/sql/storage/attach_secret.test
@@ -9,7 +9,21 @@ require-env POSTGRES_TEST_DATABASE_AVAILABLE
 statement ok
 PRAGMA enable_verification
 
-# basic secret attach workflow
+# attach using default secret
+statement ok
+CREATE SECRET (
+	TYPE POSTGRES,
+	HOST '127.0.0.1',
+	DATABASE unknown_db,
+	PASSWORD ''
+);
+
+statement error
+ATTACH '' AS secret_attach (TYPE POSTGRES)
+----
+unknown_db
+
+# attach using an explicit secret
 statement ok
 CREATE SECRET postgres_db (
 	TYPE POSTGRES,

--- a/test/sql/storage/attach_secret.test
+++ b/test/sql/storage/attach_secret.test
@@ -1,0 +1,57 @@
+# name: test/sql/storage/attach_secret.test
+# description: Test attaching using a secret
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+# basic secret attach workflow
+statement ok
+CREATE SECRET postgres_db (
+	TYPE POSTGRES,
+	HOST '127.0.0.1',
+	DATABASE postgresscanner,
+	PASSWORD ''
+);
+
+statement ok
+ATTACH '' AS secret_attach (TYPE POSTGRES, SECRET postgres_db)
+
+statement ok
+DETACH secret_attach
+
+statement ok
+CREATE OR REPLACE SECRET postgres_db (
+	TYPE POSTGRES,
+	HOST '127.0.0.1',
+	DBNAME unknown_database,
+	PASSWORD ''
+);
+
+# non-existent database
+statement error
+ATTACH '' AS secret_attach (TYPE POSTGRES, SECRET postgres_db)
+----
+unknown_database
+
+# we can override options in the attach string
+statement ok
+ATTACH 'dbname=postgresscanner' AS secret_attach (TYPE POSTGRES, SECRET postgres_db)
+
+statement error
+CREATE SECRET new_secret (
+	TYPE POSTGRES,
+	UNKNOWN_OPTION xx
+);
+----
+unknown_option
+
+# unknown secret
+statement error
+ATTACH '' AS secret_attach (TYPE POSTGRES, SECRET unknown_secret)
+----
+unknown_secret


### PR DESCRIPTION
Implements #213

This allows credentials to be managed using secrets. The secret to be used can be selected with the `SECRET` setting that is passed into `ATTACH`. There is also a default secret - this is the secret that is created without specifying a name. When no secret is provided to `ATTACH`, and such a secret is present, this secret is used.

Secrets can provide the following set of options.

|    Name    |             Description              |
|------------|--------------------------------------|
| `dbname`   | Database name                        |
| `database` | Alias for dbname                     |
| `user`     | Postgres user name                   |
| `password` | Postgres password                    |
| `host`     | Name of host to connect to           |
| `port`     | Port number                          |

Note that not all of these need to be provided. For options that are not provided, the system falls back to the regular set of default options as specified [in the configuration](https://duckdb.org/docs/extensions/postgres#configuration).

##### Implicit (Default) Secret With All Options
```sql
CREATE SECRET (
	TYPE POSTGRES,
	HOST '127.0.0.1',
        PORT 5432,
	DATABASE postgresscanner,
        USER 'postgres',
	PASSWORD ''
);
ATTACH '' AS secret_attach (TYPE POSTGRES);
```

##### Explicit (Named) Secret With Limited Options
```sql
CREATE SECRET postgres_secret(
	TYPE POSTGRES,
	HOST '127.0.0.1',
	DATABASE postgresscanner,
	PASSWORD ''
);

ATTACH '' AS secret_attach (TYPE POSTGRES, SECRET postgres_secret);
```

##### Overriding Options
Secrets essentially provide a new set of **default** options. The individual options can be overridden in the attach string, similar to how they can be overridden for the standard set of default options. For example:

```sql
CREATE SECRET (
	TYPE POSTGRES,
	HOST '127.0.0.1',
        PORT 5432,
	DATABASE postgresscanner,
        USER 'postgres',
	PASSWORD ''
);
-- override the dbname option, but use the rest of the options provided in the secret
ATTACH 'dbname=unknown_db_name' AS secret_attach (TYPE POSTGRES);
-- FATAL:  database "unknown_db_name" does not exist
```



