### PR TITLE
Fix #225 - add support for pg_temp

### DIFF
--- a/src/include/storage/postgres_transaction.hpp
+++ b/src/include/storage/postgres_transaction.hpp
@@ -40,6 +40,7 @@ private:
 	PostgresPoolConnection connection;
 	PostgresTransactionState transaction_state;
 	AccessMode access_mode;
+	string temporary_schema;
 
 private:
 	//! Retrieves the connection **without** starting a transaction if none is active

--- a/src/include/storage/postgres_transaction.hpp
+++ b/src/include/storage/postgres_transaction.hpp
@@ -34,6 +34,8 @@ public:
 	vector<unique_ptr<PostgresResult>> ExecuteQueries(const string &queries);
 	static PostgresTransaction &Get(ClientContext &context, Catalog &catalog);
 
+	string GetTemporarySchema();
+
 private:
 	PostgresPoolConnection connection;
 	PostgresTransactionState transaction_state;

--- a/src/storage/postgres_catalog.cpp
+++ b/src/storage/postgres_catalog.cpp
@@ -65,6 +65,9 @@ optional_ptr<SchemaCatalogEntry> PostgresCatalog::GetSchema(CatalogTransaction t
 		return GetSchema(transaction, "public", if_not_found, error_context);
 	}
 	auto &postgres_transaction = PostgresTransaction::Get(transaction.GetContext(), *this);
+	if (schema_name == "pg_temp") {
+		return GetSchema(transaction, postgres_transaction.GetTemporarySchema(), if_not_found, error_context);
+	}
 	auto entry = schemas.GetEntry(transaction.GetContext(), schema_name);
 	if (!entry && if_not_found != OnEntryNotFound::RETURN_NULL) {
 		throw BinderException("Schema with name \"%s\" not found", schema_name);

--- a/src/storage/postgres_table_entry.cpp
+++ b/src/storage/postgres_table_entry.cpp
@@ -32,7 +32,7 @@ unique_ptr<BaseStatistics> PostgresTableEntry::GetStatistics(ClientContext &cont
 }
 
 void PostgresTableEntry::BindUpdateConstraints(Binder &binder, LogicalGet &, LogicalProjection &, LogicalUpdate &,
-											   ClientContext &) {
+                                               ClientContext &) {
 }
 
 TableFunction PostgresTableEntry::GetScanFunction(ClientContext &context, unique_ptr<FunctionData> &bind_data) {

--- a/src/storage/postgres_transaction.cpp
+++ b/src/storage/postgres_transaction.cpp
@@ -80,17 +80,20 @@ vector<unique_ptr<PostgresResult>> PostgresTransaction::ExecuteQueries(const str
 }
 
 string PostgresTransaction::GetTemporarySchema() {
-	auto result = Query("SELECT nspname FROM pg_namespace WHERE oid = pg_my_temp_schema();");
-	if (result->Count() < 1) {
-		// no temporary tables exist yet in this connection
-		// create a random temporary table and return
-		Query("CREATE TEMPORARY TABLE __internal_temporary_table(i INTEGER)");
-		result = Query("SELECT nspname FROM pg_namespace WHERE oid = pg_my_temp_schema();");
+	if (temporary_schema.empty()) {
+		auto result = Query("SELECT nspname FROM pg_namespace WHERE oid = pg_my_temp_schema();");
 		if (result->Count() < 1) {
-			throw BinderException("Could not find temporary schema pg_temp_NNN for this connection");
+			// no temporary tables exist yet in this connection
+			// create a random temporary table and return
+			Query("CREATE TEMPORARY TABLE __internal_temporary_table(i INTEGER)");
+			result = Query("SELECT nspname FROM pg_namespace WHERE oid = pg_my_temp_schema();");
+			if (result->Count() < 1) {
+				throw BinderException("Could not find temporary schema pg_temp_NNN for this connection");
+			}
 		}
+		temporary_schema = result->GetString(0, 0);
 	}
-	return result->GetString(0, 0);
+	return temporary_schema;
 }
 
 PostgresTransaction &PostgresTransaction::Get(ClientContext &context, Catalog &catalog) {

--- a/src/storage/postgres_transaction.cpp
+++ b/src/storage/postgres_transaction.cpp
@@ -79,6 +79,20 @@ vector<unique_ptr<PostgresResult>> PostgresTransaction::ExecuteQueries(const str
 	return con.ExecuteQueries(queries);
 }
 
+string PostgresTransaction::GetTemporarySchema() {
+	auto result = Query("SELECT nspname FROM pg_namespace WHERE oid = pg_my_temp_schema();");
+	if (result->Count() < 1) {
+		// no temporary tables exist yet in this connection
+		// create a random temporary table and return
+		Query("CREATE TEMPORARY TABLE __internal_temporary_table(i INTEGER)");
+		result = Query("SELECT nspname FROM pg_namespace WHERE oid = pg_my_temp_schema();");
+		if (result->Count() < 1) {
+			throw BinderException("Could not find temporary schema pg_temp_NNN for this connection");
+		}
+	}
+	return result->GetString(0, 0);
+}
+
 PostgresTransaction &PostgresTransaction::Get(ClientContext &context, Catalog &catalog) {
 	return Transaction::Get(context, catalog).Cast<PostgresTransaction>();
 }

--- a/test/sql/storage/attach_temporary_table.test
+++ b/test/sql/storage/attach_temporary_table.test
@@ -1,0 +1,28 @@
+# name: test/sql/storage/attach_temporary_table.test
+# description: Test attaching and querying a Postgres temporary table
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'postgres:dbname=postgresscanner' AS s
+
+statement ok
+CREATE TABLE s.pg_temp.my_datasets(val VARCHAR)
+
+query I
+SELECT * FROM s.pg_temp.my_datasets
+----
+
+statement ok
+INSERT INTO s.pg_temp.my_datasets VALUES ('hello world')
+
+query I
+SELECT * FROM s.pg_temp.my_datasets
+----
+hello world


### PR DESCRIPTION
Fixes #225 

Add support for the `pg_temp` schema by replacing `pg_temp` with the actual `pg_temp_XX` schema - found through the query:

```sql
SELECT nspname FROM pg_namespace WHERE oid = pg_my_temp_schema();
````

If `pg_temp` is used before it is instantiated, we force instantiation in Postgres by creating a temporary table using the query:

```sql
CREATE TEMPORARY TABLE __internal_temporary_table(i INTEGER)
```