### PR TITLE
Bump to latest duckdb, absorb patches

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -14,19 +14,19 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.0.0
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
-      duckdb_version: v1.0.0
+      duckdb_version: main
       extension_name: postgres_scanner
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
 
   duckdb-stable-deploy:
     name: Deploy extension binaries
     needs: duckdb-stable-build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.0.0
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@main
     secrets: inherit
     with:
-      duckdb_version: v1.0.0
+      duckdb_version: main
       extension_name: postgres_scanner
       exclude_archs: 'wasm_mvp;wasm_eh;wasm_threads;windows_amd64_rtools'
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/src/include/storage/postgres_delete.hpp
+++ b/src/include/storage/postgres_delete.hpp
@@ -44,7 +44,7 @@ public:
 	}
 
 	string GetName() const override;
-	string ParamsToString() const override;
+	InsertionOrderPreservingMap<string> ParamsToString() const override;
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_insert.hpp
+++ b/src/include/storage/postgres_insert.hpp
@@ -53,7 +53,7 @@ public:
 	}
 
 	string GetName() const override;
-	string ParamsToString() const override;
+	InsertionOrderPreservingMap<string> ParamsToString() const override;
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_update.hpp
+++ b/src/include/storage/postgres_update.hpp
@@ -46,7 +46,7 @@ public:
 	}
 
 	string GetName() const override;
-	string ParamsToString() const override;
+	InsertionOrderPreservingMap<string> ParamsToString() const override;
 };
 
 } // namespace duckdb

--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -48,7 +48,7 @@ public:
 class PostgresExtensionCallback : public ExtensionCallback {
 public:
 	void OnConnectionOpened(ClientContext &context) override {
-		context.registered_state.insert(make_pair("postgres_extension", make_shared_ptr<PostgresExtensionState>()));
+		context.registered_state->Insert("postgres_extension", make_shared_ptr<PostgresExtensionState>());
 	}
 };
 
@@ -174,7 +174,7 @@ static void LoadInternal(DatabaseInstance &db) {
 
 	config.extension_callbacks.push_back(make_uniq<PostgresExtensionCallback>());
 	for (auto &connection : ConnectionManager::Get(db).GetConnectionList()) {
-		connection->registered_state.insert(make_pair("postgres_extension", make_shared_ptr<PostgresExtensionState>()));
+		connection->registered_state->Insert("postgres_extension", make_shared_ptr<PostgresExtensionState>());
 	}
 }
 

--- a/src/storage/postgres_delete.cpp
+++ b/src/storage/postgres_delete.cpp
@@ -110,8 +110,10 @@ string PostgresDelete::GetName() const {
 	return "PG_DELETE";
 }
 
-string PostgresDelete::ParamsToString() const {
-	return table.name;
+InsertionOrderPreservingMap<string> PostgresDelete::ParamsToString() const {
+	InsertionOrderPreservingMap<string> result;
+	result["Table Name"] = table.name;
+	return result;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/postgres_insert.cpp
+++ b/src/storage/postgres_insert.cpp
@@ -144,8 +144,10 @@ string PostgresInsert::GetName() const {
 	return table ? "PG_INSERT" : "PG_CREATE_TABLE_AS";
 }
 
-string PostgresInsert::ParamsToString() const {
-	return table ? table->name : info->Base().table;
+InsertionOrderPreservingMap<string> PostgresInsert::ParamsToString() const {
+	InsertionOrderPreservingMap<string> result;
+	result["Table Name"] = table ? table->name : info->Base().table;
+	return result;
 }
 
 //===--------------------------------------------------------------------===//

--- a/src/storage/postgres_update.cpp
+++ b/src/storage/postgres_update.cpp
@@ -171,8 +171,10 @@ string PostgresUpdate::GetName() const {
 	return "PG_UPDATE";
 }
 
-string PostgresUpdate::ParamsToString() const {
-	return table.name;
+InsertionOrderPreservingMap<string> PostgresUpdate::ParamsToString() const {
+	InsertionOrderPreservingMap<string> result;
+	result["Table Name"] = table.name;
+	return result;
 }
 
 //===--------------------------------------------------------------------===//


### PR DESCRIPTION
There are some issues with the tests performed by Linux.yml, that needs to be looked at.

Note that some might be already there since the move to duckdb v1.0.0.

Given these are preexisting, and bumping version do not preclude compilation / problem is minor, I think this can go in independently.