### PR TITLE
Fix #250 - always quote column names in CREATE TABLE to avoid Postgres' lowercasing them

### DIFF
--- a/src/storage/postgres_table_set.cpp
+++ b/src/storage/postgres_table_set.cpp
@@ -255,7 +255,7 @@ string PostgresColumnsToSQL(const ColumnList &columns, const vector<unique_ptr<C
 		if (column.Oid() > 0) {
 			ss << ", ";
 		}
-		ss << KeywordHelper::WriteOptionallyQuoted(column.Name()) << " ";
+		ss << KeywordHelper::WriteQuoted(column.Name(), '"') << " ";
 		ss << PostgresUtils::TypeToString(column.Type());
 		bool not_null = not_null_columns.find(column.Logical()) != not_null_columns.end();
 		bool is_single_key_pk = pk_columns.find(column.Logical()) != pk_columns.end();

--- a/test/sql/storage/attach_create_uppercase_names.test
+++ b/test/sql/storage/attach_create_uppercase_names.test
@@ -1,0 +1,24 @@
+# name: test/sql/storage/attach_create_uppercase_names.test
+# description: Test creating tables with uppercase column names
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+USE s
+
+statement ok
+CREATE OR REPLACE TABLE MyTable AS SELECT 42 MyColumn, 84 MySecondColumn
+
+query II
+SELECT MyColumn, MySecondColumn FROM MyTable
+----
+42	84


### PR DESCRIPTION
Fixes #250 