### PR TITLE
Fix #228: explicitly handle NULL bytes in strings by throwing a helpful error message, and add a setting pg_null_byte_replacement which can be used to replace them

### DIFF
--- a/src/include/postgres_binary_writer.hpp
+++ b/src/include/postgres_binary_writer.hpp
@@ -200,6 +200,13 @@ public:
 		}
 	}
 
+	void WriteRawBlob(string_t value) {
+		auto str_size = value.GetSize();
+		auto str_data = value.GetData();
+		WriteRawInteger<int32_t>(NumericCast<int32_t>(str_size));
+		stream.WriteData(const_data_ptr_cast(str_data), str_size);
+	}
+
 	void WriteVarchar(string_t value) {
 		auto str_size = value.GetSize();
 		auto str_data = value.GetData();
@@ -219,11 +226,10 @@ public:
 					new_str += str_data[i];
 				}
 			}
-			WriteVarchar(new_str);
+			WriteRawBlob(new_str);
 			return;
 		}
-		WriteRawInteger<int32_t>(NumericCast<int32_t>(str_size));
-		stream.WriteData(const_data_ptr_cast(str_data), str_size);
+		WriteRawBlob(value);
 	}
 
 	void WriteArray(Vector &col, idx_t r, const vector<uint32_t> &dimensions, idx_t depth, uint32_t count) {
@@ -336,10 +342,14 @@ public:
 			WriteUUID(data);
 			break;
 		}
-		case LogicalTypeId::BLOB:
 		case LogicalTypeId::VARCHAR: {
 			auto data = FlatVector::GetData<string_t>(col)[r];
 			WriteVarchar(data);
+			break;
+		}
+		case LogicalTypeId::BLOB: {
+			auto data = FlatVector::GetData<string_t>(col)[r];
+			WriteRawBlob(data);
 			break;
 		}
 		case LogicalTypeId::ENUM: {

--- a/src/include/postgres_connection.hpp
+++ b/src/include/postgres_connection.hpp
@@ -29,10 +29,6 @@ struct OwnedPostgresConnection {
 	PGconn *connection;
 };
 
-struct PostgresCopyState {
-	PostgresCopyFormat format = PostgresCopyFormat::AUTO;
-};
-
 class PostgresConnection {
 public:
 	explicit PostgresConnection(shared_ptr<OwnedPostgresConnection> connection = nullptr);

--- a/src/include/postgres_utils.hpp
+++ b/src/include/postgres_utils.hpp
@@ -46,6 +46,14 @@ struct PostgresType {
 
 enum class PostgresCopyFormat { AUTO = 0, BINARY = 1, TEXT = 2 };
 
+struct PostgresCopyState {
+	PostgresCopyFormat format = PostgresCopyFormat::AUTO;
+	bool has_null_byte_replacement = false;
+	string null_byte_replacement;
+
+	void Initialize(ClientContext &context);
+};
+
 class PostgresUtils {
 public:
 	static PGconn *PGConnect(const string &dsn);

--- a/src/postgres_copy_to.cpp
+++ b/src/postgres_copy_to.cpp
@@ -5,6 +5,24 @@
 
 namespace duckdb {
 
+void PostgresCopyState::Initialize(ClientContext &context) {
+	Value replacement_value;
+	if (!context.TryGetCurrentSetting("pg_null_byte_replacement", replacement_value)) {
+		return;
+	}
+	if (replacement_value.IsNull()) {
+		return;
+	}
+	auto replacement_str = StringValue::Get(replacement_value);
+	for (const auto c : replacement_str) {
+		if (c == '\0') {
+			throw InternalException("NULL byte replacement string cannot contain NULL values");
+		}
+	}
+	has_null_byte_replacement = true;
+	null_byte_replacement = std::move(replacement_str);
+}
+
 void PostgresConnection::BeginCopyTo(ClientContext &context, PostgresCopyState &state, PostgresCopyFormat format,
                                      const string &schema_name, const string &table_name,
                                      const vector<string> &column_names) {
@@ -24,6 +42,7 @@ void PostgresConnection::BeginCopyTo(ClientContext &context, PostgresCopyState &
 		query += ") ";
 	}
 	query += "FROM STDIN (FORMAT ";
+	state.Initialize(context);
 	state.format = format;
 	switch (state.format) {
 	case PostgresCopyFormat::BINARY:
@@ -43,7 +62,7 @@ void PostgresConnection::BeginCopyTo(ClientContext &context, PostgresCopyState &
 	}
 	if (state.format == PostgresCopyFormat::BINARY) {
 		// binary copy requires a header
-		PostgresBinaryWriter writer;
+		PostgresBinaryWriter writer(state);
 		writer.WriteHeader();
 		CopyData(writer);
 	}
@@ -70,12 +89,12 @@ void PostgresConnection::CopyData(PostgresTextWriter &writer) {
 void PostgresConnection::FinishCopyTo(PostgresCopyState &state) {
 	if (state.format == PostgresCopyFormat::BINARY) {
 		// binary copy requires a footer
-		PostgresBinaryWriter writer;
+		PostgresBinaryWriter writer(state);
 		writer.WriteFooter();
 		CopyData(writer);
 	} else if (state.format == PostgresCopyFormat::TEXT) {
 		// text copy requires a footer
-		PostgresTextWriter writer;
+		PostgresTextWriter writer(state);
 		writer.WriteFooter();
 		CopyData(writer);
 	}
@@ -263,7 +282,7 @@ void PostgresConnection::CopyChunk(ClientContext &context, PostgresCopyState &st
 	chunk.Flatten();
 
 	if (state.format == PostgresCopyFormat::BINARY) {
-		PostgresBinaryWriter writer;
+		PostgresBinaryWriter writer(state);
 		for (idx_t r = 0; r < chunk.size(); r++) {
 			writer.BeginRow(chunk.ColumnCount());
 			for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
@@ -290,7 +309,7 @@ void PostgresConnection::CopyChunk(ClientContext &context, PostgresCopyState &st
 		}
 		varchar_chunk.SetCardinality(chunk.size());
 
-		PostgresTextWriter writer;
+		PostgresTextWriter writer(state);
 		for (idx_t r = 0; r < chunk.size(); r++) {
 			for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
 				if (c > 0) {

--- a/test/sql/storage/attach_null_byte.test
+++ b/test/sql/storage/attach_null_byte.test
@@ -1,0 +1,65 @@
+# name: test/sql/storage/attach_null_byte.test
+# description: Test inserting null byte values through ATTACH
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s1 (TYPE POSTGRES)
+
+statement ok
+USE s1
+
+foreach pg_binary true false
+
+statement ok
+SET pg_use_binary_copy=${pg_binary}
+
+statement ok
+CREATE OR REPLACE TABLE nullbyte_tbl(s VARCHAR);
+
+statement error
+INSERT INTO nullbyte_tbl VALUES (chr(0))
+----
+Postgres does not support NULL-bytes in VARCHAR values
+
+statement ok
+SET pg_null_byte_replacement=''
+
+statement ok
+INSERT INTO nullbyte_tbl VALUES (chr(0)), ('FF' || chr(0) || 'FF');
+
+query I
+SELECT * FROM nullbyte_tbl
+----
+(empty)
+FFFF
+
+statement ok
+SET pg_null_byte_replacement='NULLBYTE'
+
+statement ok
+INSERT INTO nullbyte_tbl VALUES (chr(0)), ('FF' || chr(0) || 'FF');
+
+query I
+SELECT * FROM nullbyte_tbl
+----
+(empty)
+FFFF
+NULLBYTE
+FFNULLBYTEFF
+
+statement ok
+RESET pg_null_byte_replacement
+
+endloop
+
+statement error
+SET pg_null_byte_replacement=chr(0)
+----
+NULL byte replacement string cannot contain NULL values


### PR DESCRIPTION
Fixes #228 

Postgres does not support null bytes in strings - but DuckDB does.
We now throw a helpful error when a null byte is attempted to be inserted in Postgres:

```sql
INSERT INTO nullbyte_tbl VALUES (chr(0));
-- Invalid Input Error: Attempting to write a VARCHAR value with a NULL-byte. Postgres does not support NULL-bytes in VARCHAR values.
-- * SET pg_null_byte_replacement='' to remove NULL bytes or replace them with another character
```

In addition we add the `pg_null_byte_replacement` setting, that can be used to either (1) remove null-bytes, or (2) replace them with a replacement value, e.g.:

```sql
SET pg_null_byte_replacement='NULLBYTE';
INSERT INTO nullbyte_tbl VALUES (chr(0));
SELECT * FROM nullbyte_tbl;
-- NULLBYTE
```