### PR TITLE
Fix  #246 - convert ubigint to `decimal(20,0)` instead of to double to avoid loss of precision

### DIFF
--- a/src/postgres_utils.cpp
+++ b/src/postgres_utils.cpp
@@ -253,6 +253,7 @@ LogicalType PostgresUtils::ToPostgresType(const LogicalType &input) {
 	case LogicalTypeId::UINTEGER:
 		return LogicalType::BIGINT;
 	case LogicalTypeId::UBIGINT:
+          return LogicalType::DECIMAL(20, 0);
 	case LogicalTypeId::HUGEINT:
 		return LogicalType::DOUBLE;
 	default:

--- a/test/sql/storage/attach_ubigint.test
+++ b/test/sql/storage/attach_ubigint.test
@@ -1,0 +1,27 @@
+# name: test/sql/storage/attach_ubigint.test
+# description: Test inserting/querying UBIGINT
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+USE s;
+
+statement ok
+CREATE OR REPLACE TABLE ubigints(u UBIGINT);
+
+statement ok
+INSERT INTO ubigints VALUES (1394265502879208448);
+
+query I
+SELECT u::VARCHAR FROM ubigints
+----
+1394265502879208448


### PR DESCRIPTION
Fixes #246 