### PR TITLE
Fix #222: use PQexec instead of PQsendQuery for postgres_execute

### DIFF
--- a/src/postgres_execute.cpp
+++ b/src/postgres_execute.cpp
@@ -45,7 +45,7 @@ static void PGExecuteFunction(ClientContext &context, TableFunctionInput &data_p
 		return;
 	}
 	auto &transaction = Transaction::Get(context, data.pg_catalog).Cast<PostgresTransaction>();
-	transaction.ExecuteQueries(data.query);
+	transaction.Query(data.query);
 	data.finished = true;
 }
 

--- a/test/sql/storage/postgres_execute_transaction.test
+++ b/test/sql/storage/postgres_execute_transaction.test
@@ -1,0 +1,54 @@
+# name: test/sql/storage/postgres_execute_transaction.test
+# description: Test interactions of postgres_execute and transactions
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+CREATE OR REPLACE TABLE s.postgres_execute_attempt(i INTEGER);
+
+statement ok
+BEGIN
+
+query I
+CALL postgres_query('s', 'SELECT 42')
+----
+42
+
+statement ok
+CALL postgres_execute('s', 'INSERT INTO postgres_execute_attempt VALUES (42)')
+
+statement ok
+ROLLBACK
+
+query I
+FROM s.postgres_execute_attempt
+----
+
+statement ok
+BEGIN
+
+query I
+CALL postgres_query('s', 'SELECT 42')
+----
+42
+
+statement ok
+CALL postgres_execute('s', 'INSERT INTO postgres_execute_attempt VALUES (42); INSERT INTO postgres_execute_attempt VALUES (84)')
+
+statement ok
+COMMIT
+
+query I
+FROM s.postgres_execute_attempt
+----
+42
+84


### PR DESCRIPTION
Fixes #222 

This is a strange behavior in `libpq` - when executing a `COPY`, the connection enters a copy mode, and there seems to be no way of exiting this. `PQsendQuery` fails with the `another command is already in progress` error if the connection is in `COPY` mode, but somehow `PQexec` has no problem running queries. Since we don't care about the result set when using `postgres_execute` we can just call `PQexec` instead.