### PR TITLE
Fix #221: add the SCHEMA parameter to ATTACH that allows you to specify which schema to load

### DIFF
--- a/src/include/storage/postgres_catalog.hpp
+++ b/src/include/storage/postgres_catalog.hpp
@@ -20,7 +20,7 @@ class PostgresSchemaEntry;
 
 class PostgresCatalog : public Catalog {
 public:
-	explicit PostgresCatalog(AttachedDatabase &db_p, const string &path, AccessMode access_mode);
+	explicit PostgresCatalog(AttachedDatabase &db_p, const string &path, AccessMode access_mode, string schema_to_load);
 	~PostgresCatalog();
 
 	string path;
@@ -93,6 +93,7 @@ private:
 	PostgresVersion version;
 	PostgresSchemaSet schemas;
 	PostgresConnectionPool connection_pool;
+	string default_schema;
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_index_set.hpp
+++ b/src/include/storage/postgres_index_set.hpp
@@ -20,7 +20,7 @@ public:
 	PostgresIndexSet(PostgresSchemaEntry &schema, unique_ptr<PostgresResultSlice> index_result = nullptr);
 
 public:
-	static string GetInitializeQuery();
+	static string GetInitializeQuery(const string &schema = string());
 
 	optional_ptr<CatalogEntry> CreateIndex(ClientContext &context, CreateIndexInfo &info, TableCatalogEntry &table);
 

--- a/src/include/storage/postgres_schema_set.hpp
+++ b/src/include/storage/postgres_schema_set.hpp
@@ -16,15 +16,19 @@ struct CreateSchemaInfo;
 
 class PostgresSchemaSet : public PostgresCatalogSet {
 public:
-	explicit PostgresSchemaSet(Catalog &catalog);
+	explicit PostgresSchemaSet(Catalog &catalog, string schema_to_load);
 
 public:
 	optional_ptr<CatalogEntry> CreateSchema(ClientContext &context, CreateSchemaInfo &info);
 
-	static string GetInitializeQuery();
+	static string GetInitializeQuery(const string &schema = string());
 
 protected:
 	void LoadEntries(ClientContext &context) override;
+
+protected:
+	//! Schema to load - if empty loads all schemas (default behavior)
+	string schema_to_load;
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_type_set.hpp
+++ b/src/include/storage/postgres_type_set.hpp
@@ -25,8 +25,8 @@ public:
 public:
 	optional_ptr<CatalogEntry> CreateType(ClientContext &context, CreateTypeInfo &info);
 
-	static string GetInitializeEnumsQuery(PostgresVersion version);
-	static string GetInitializeCompositesQuery();
+	static string GetInitializeEnumsQuery(PostgresVersion version, const string &schema = string());
+	static string GetInitializeCompositesQuery(const string &schema = string());
 
 protected:
 	bool HasInternalDependencies() const override {

--- a/src/postgres_storage.cpp
+++ b/src/postgres_storage.cpp
@@ -58,12 +58,15 @@ static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, Cl
 	string connection_string = info.path;
 
 	string secret_name;
+	string schema_to_load;
 	for (auto &entry : info.options) {
 		auto lower_name = StringUtil::Lower(entry.first);
 		if (lower_name == "type" || lower_name == "read_only") {
 			// already handled
 		} else if (lower_name == "secret") {
 			secret_name = entry.second.ToString();
+		} else if (lower_name == "schema") {
+			schema_to_load = entry.second.ToString();
 		} else {
 			throw BinderException("Unrecognized option for Postgres attach: %s", entry.first);
 		}
@@ -93,7 +96,7 @@ static unique_ptr<Catalog> PostgresAttach(StorageExtensionInfo *storage_info, Cl
 		// secret not found and one was explicitly provided - throw an error
 		throw BinderException("Secret with name \"%s\" not found", secret_name);
 	}
-	return make_uniq<PostgresCatalog>(db, connection_string, access_mode);
+	return make_uniq<PostgresCatalog>(db, connection_string, access_mode, std::move(schema_to_load));
 }
 
 static unique_ptr<TransactionManager> PostgresCreateTransactionManager(StorageExtensionInfo *storage_info,

--- a/test/other.sql
+++ b/test/other.sql
@@ -104,7 +104,7 @@ CREATE TABLE my_table (
 insert into my_table values (42, 'something', 'something else');
 
 
-	CREATE SCHEMA some_schema;
+CREATE SCHEMA some_schema;
 
 create type some_schema.some_enum as enum('one', 'two');
 

--- a/test/sql/storage/attach_schema_param.test
+++ b/test/sql/storage/attach_schema_param.test
@@ -1,0 +1,36 @@
+# name: test/sql/storage/attach_schema_param.test
+# description: Test attaching only a specific schema
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, SCHEMA 'some_schema')
+
+query I
+SELECT * FROM s.some_schema.some_table
+----
+two
+
+query I
+SELECT * FROM s.some_table
+----
+two
+
+statement error
+SELECT * FROM s.public.my_table
+----
+does not exist
+
+statement ok
+USE s;
+
+query I
+SELECT * FROM some_table
+----
+two


### PR DESCRIPTION
Fixes #221 

This adds the `SCHEMA` parameter to `ATTACH`, which (1) limits the catalog entries that are loaded to only those in that schema, and (2) sets that schema as the default schema (instead of `public`). For example:

```sql
ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, SCHEMA 'some_schema');
SELECT * FROM s.some_table; -- reads from s.some_schema.some_table;
```

When there are many schemas in a database, this can speed up the attach as only a single schema's catalog entries are fetched.
