### PR TITLE
fix(postgres_text_reader.cpp): reset PGresult when result set is fully consumed to free resources immediately

### DIFF
--- a/src/postgres_text_reader.cpp
+++ b/src/postgres_text_reader.cpp
@@ -365,7 +365,14 @@ PostgresReadResult PostgresTextReader::Read(DataChunk &output) {
 		}
 	}
 	output.SetCardinality(scan_chunk.size());
-	return row_offset < result->Count() ? PostgresReadResult::HAVE_MORE_TUPLES : PostgresReadResult::FINISHED;
+
+	bool finished = row_offset >= result->Count();
+	if (finished) {
+		// The result set is fully consumed. Reset immediately to free the PGresult.
+		Reset();
+		return PostgresReadResult::FINISHED;
+	}
+	return PostgresReadResult::HAVE_MORE_TUPLES;
 }
 
 void PostgresTextReader::Reset() {


### PR DESCRIPTION
<img width="1500" height="900" alt="image" src="https://github.com/user-attachments/assets/b0ca7233-8b12-41a3-a935-0a1b52c707ae" />

I've sucesfully tested this and the blue line is the builded from based from commit 482b5702f7 compared to previous published version

More info: https://github.com/duckdb/duckdb-postgres/issues/361