### PR TITLE
Add postgres secret store

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(
   postgres_filter_pushdown.cpp
   postgres_query.cpp
   postgres_scanner.cpp
+  postgres_secret_storage.cpp
   postgres_storage.cpp
   postgres_text_reader.cpp
   postgres_utils.cpp)

--- a/src/include/postgres_secret_storage.hpp
+++ b/src/include/postgres_secret_storage.hpp
@@ -38,13 +38,14 @@ public:
                                           optional_ptr<CatalogTransaction> transaction = nullptr) override;
 
 private:
-  void InitializeSecretsTable();
+  void InitializeSecretsTable(PostgresCatalog &postgres_catalog);
   string SerializeSecret(const BaseSecret &secret);
   unique_ptr<const BaseSecret> DeserializeSecret(const string &hex_string, const string &secret_name);
+  PostgresCatalog *GetPostgresCatalog(ClientContext &context);
 
   DatabaseInstance &db;
   SecretManager &secret_manager;
-  PostgresCatalog &postgres_catalog;
+  string attached_database_name;
   string secrets_table_name;
 
   static std::atomic<int64_t> next_tie_break_offset;

--- a/src/include/postgres_secret_storage.hpp
+++ b/src/include/postgres_secret_storage.hpp
@@ -18,8 +18,7 @@ class PostgresCatalog;
 
 class PostgresSecretStorage : public SecretStorage {
 public:
-  PostgresSecretStorage(const string &name_p, DatabaseInstance &db,
-                        PostgresCatalog &postgres_catalog, SecretManager &secret_manager);
+  PostgresSecretStorage(const string &name_p, PostgresCatalog &postgres_catalog, SecretManager &secret_manager);
   ~PostgresSecretStorage() override;
 
   bool IncludeInLookups() override { return true; }
@@ -43,7 +42,6 @@ private:
   unique_ptr<const BaseSecret> DeserializeSecret(const string &hex_string, const string &secret_name);
   PostgresCatalog *GetPostgresCatalog(ClientContext &context);
 
-  DatabaseInstance &db;
   SecretManager &secret_manager;
   string attached_database_name;
   string secrets_table_name;

--- a/src/include/postgres_secret_storage.hpp
+++ b/src/include/postgres_secret_storage.hpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// postgres_secret_storage.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb/main/secret/secret_storage.hpp"
+#include "storage/postgres_connection_pool.hpp"
+
+namespace duckdb {
+
+class PostgresCatalog;
+
+class PostgresSecretStorage : public CatalogSetSecretStorage {
+public:
+  PostgresSecretStorage(const string &name_p, DatabaseInstance &db,
+                        PostgresCatalog &postgres_catalog);
+  ~PostgresSecretStorage() override;
+
+  bool IncludeInLookups() override { return true; }
+
+  static int64_t GetNextTieBreakOffset();
+
+  static std::atomic<int64_t> next_unique_id;
+
+protected:
+  void WriteSecret(const BaseSecret &secret,
+                   OnCreateConflict on_conflict) override;
+  void RemoveSecret(const string &secret,
+                    OnEntryNotFound on_entry_not_found) override;
+
+private:
+  void InitializeSecretsTable();
+  string SerializeSecret(const BaseSecret &secret);
+
+  PostgresCatalog &postgres_catalog;
+  string secrets_table_name;
+
+  static std::atomic<int64_t> next_tie_break_offset;
+};
+
+} // namespace duckdb

--- a/src/postgres_secret_storage.cpp
+++ b/src/postgres_secret_storage.cpp
@@ -12,7 +12,6 @@ namespace duckdb {
 
 // Initialize static counters starting at 25 and 0
 std::atomic<int64_t> PostgresSecretStorage::next_tie_break_offset(25);
-std::atomic<int64_t> PostgresSecretStorage::next_unique_id(0);
 
 int64_t PostgresSecretStorage::GetNextTieBreakOffset() {
 	return next_tie_break_offset.fetch_add(1);
@@ -126,30 +125,6 @@ void PostgresSecretStorage::RemoveSecret(const string &secret, OnEntryNotFound o
 	// Get a connection from the pool
 	auto pool_connection = postgres_catalog.GetConnectionPool().GetConnection();
 	auto &connection = pool_connection.GetConnection();
-
-	// Check if the secret exists first if we need to throw an error
-	if (on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
-		auto escape_sql = [](const string &str) -> string {
-			string result;
-			for (char c : str) {
-				if (c == '\'') {
-					result += "''";
-				} else {
-					result += c;
-				}
-			}
-			return result;
-		};
-
-		string escaped_name = escape_sql(secret);
-		string check_query = StringUtil::Format("SELECT COUNT(*) FROM %s WHERE secret_name = '%s'",
-		                                        secrets_table_name, escaped_name);
-
-		auto result = connection.Query(check_query);
-		// Parse result to check if secret exists
-		// If count is 0, throw exception
-		// Note: This is a simplified check - you may need to parse the actual result
-	}
 
 	// Delete the secret
 	auto escape_sql = [](const string &str) -> string {

--- a/src/postgres_secret_storage.cpp
+++ b/src/postgres_secret_storage.cpp
@@ -34,9 +34,9 @@ int64_t PostgresSecretStorage::GetNextTieBreakOffset() {
 	return next_tie_break_offset.fetch_add(1);
 }
 
-PostgresSecretStorage::PostgresSecretStorage(const string &name_p, DatabaseInstance &db_p,
-                                             PostgresCatalog &postgres_catalog_p, SecretManager &secret_manager_p)
-    : SecretStorage(name_p, GetNextTieBreakOffset()), db(db_p), secret_manager(secret_manager_p),
+PostgresSecretStorage::PostgresSecretStorage(const string &name_p, PostgresCatalog &postgres_catalog_p, 
+											 SecretManager &secret_manager_p)
+    : SecretStorage(name_p, GetNextTieBreakOffset()), secret_manager(secret_manager_p),
       attached_database_name(postgres_catalog_p.GetAttached().GetName()), secrets_table_name("duckdb_secrets") {
 	persistent = true;
 

--- a/src/postgres_secret_storage.cpp
+++ b/src/postgres_secret_storage.cpp
@@ -10,19 +10,30 @@
 
 namespace duckdb {
 
-// Initialize static counters starting at 25 and 0
+// Helper function to escape SQL strings
+static string EscapeSQLString(const string &str) {
+	string result;
+	for (char c : str) {
+		if (c == '\'') {
+			result += "''";
+		} else {
+			result += c;
+		}
+	}
+	return result;
+}
+
+// Initialize static counter starting at 25
 std::atomic<int64_t> PostgresSecretStorage::next_tie_break_offset(25);
 
 int64_t PostgresSecretStorage::GetNextTieBreakOffset() {
 	return next_tie_break_offset.fetch_add(1);
 }
 
-PostgresSecretStorage::PostgresSecretStorage(const string &name_p, DatabaseInstance &db,
-                                             PostgresCatalog &postgres_catalog_p)
-    : CatalogSetSecretStorage(db, name_p, GetNextTieBreakOffset()), postgres_catalog(postgres_catalog_p),
-      secrets_table_name("duckdb_secrets") {
-	// Initialize the catalog set for storing secrets
-	secrets = make_uniq<CatalogSet>(Catalog::GetSystemCatalog(db));
+PostgresSecretStorage::PostgresSecretStorage(const string &name_p, DatabaseInstance &db_p,
+                                             PostgresCatalog &postgres_catalog_p, SecretManager &secret_manager_p)
+    : SecretStorage(name_p, GetNextTieBreakOffset()), db(db_p), secret_manager(secret_manager_p),
+      postgres_catalog(postgres_catalog_p), secrets_table_name("duckdb_secrets") {
 	persistent = true;
 
 	// Create the secrets table if it doesn't exist
@@ -30,6 +41,197 @@ PostgresSecretStorage::PostgresSecretStorage(const string &name_p, DatabaseInsta
 }
 
 PostgresSecretStorage::~PostgresSecretStorage() {
+}
+
+unique_ptr<const BaseSecret> PostgresSecretStorage::DeserializeSecret(const string &hex_string_ref,
+                                                                       const string &secret_name) {
+	// Parse the hex string (format: \x followed by hex digits)
+	if (hex_string_ref.size() < 2 || hex_string_ref[0] != '\\' || hex_string_ref[1] != 'x') {
+		return nullptr;
+	}
+
+	auto hex_data = hex_string_ref.c_str() + 2;
+	auto hex_size = hex_string_ref.size() - 2;
+
+	// Convert hex to binary
+	vector<uint8_t> binary_data;
+	binary_data.reserve(hex_size / 2);
+
+	for (idx_t i = 0; i < hex_size; i += 2) {
+		uint8_t byte = 0;
+		for (idx_t j = 0; j < 2; j++) {
+			byte <<= 4;
+			char c = hex_data[i + j];
+			if (c >= '0' && c <= '9') {
+				byte |= (c - '0');
+			} else if (c >= 'a' && c <= 'f') {
+				byte |= (c - 'a' + 10);
+			} else if (c >= 'A' && c <= 'F') {
+				byte |= (c - 'A' + 10);
+			}
+		}
+		binary_data.push_back(byte);
+	}
+
+	// Deserialize the secret
+	MemoryStream stream(data_ptr_cast(binary_data.data()), binary_data.size());
+	BinaryDeserializer deserializer(stream);
+
+	deserializer.Begin();
+	auto secret = secret_manager.DeserializeSecret(deserializer, secret_name);
+	deserializer.End();
+
+	return secret;
+}
+
+unique_ptr<SecretEntry> PostgresSecretStorage::StoreSecret(unique_ptr<const BaseSecret> secret,
+                                                            OnCreateConflict on_conflict,
+                                                            optional_ptr<CatalogTransaction> transaction) {
+	auto secret_name = secret->GetName();
+	auto secret_type = secret->GetType();
+
+	// Check if secret already exists
+	auto existing = GetSecretByName(secret_name, transaction);
+	if (existing) {
+		if (on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
+			throw InvalidInputException("Persistent secret with name '%s' already exists in secret storage '%s'!",
+			                            secret_name, storage_name);
+		} else if (on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {
+			return nullptr;
+		}
+		// REPLACE_ON_CONFLICT - continue to overwrite
+	}
+
+	// Serialize the secret BEFORE moving it
+	string serialized = SerializeSecret(*secret);
+
+	// Get a connection from the pool
+	auto pool_connection = postgres_catalog.GetConnectionPool().GetConnection();
+	auto &connection = pool_connection.GetConnection();
+
+	string escaped_name = EscapeSQLString(secret_name);
+	string escaped_type = EscapeSQLString(secret_type);
+
+	// Build the INSERT query based on conflict handling
+	string query;
+	if (on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
+		query = StringUtil::Format(
+		    "INSERT INTO %s (secret_name, secret_type, serialized_secret) VALUES ('%s', '%s', E'%s')",
+		    secrets_table_name, escaped_name, escaped_type, serialized);
+	} else {
+		// REPLACE_ON_CONFLICT or IGNORE (though IGNORE is handled above)
+		query = StringUtil::Format(
+		    "INSERT INTO %s (secret_name, secret_type, serialized_secret) VALUES ('%s', '%s', E'%s') "
+		    "ON CONFLICT (secret_name) DO UPDATE SET secret_type = EXCLUDED.secret_type, "
+		    "serialized_secret = EXCLUDED.serialized_secret",
+		    secrets_table_name, escaped_name, escaped_type, serialized);
+	}
+
+	connection.Execute(query);
+
+	// Return the secret entry
+	auto secret_entry = make_uniq<SecretEntry>(std::move(secret));
+	secret_entry->storage_mode = storage_name;
+	secret_entry->persist_type = SecretPersistType::PERSISTENT;
+	return secret_entry;
+}
+
+vector<SecretEntry> PostgresSecretStorage::AllSecrets(optional_ptr<CatalogTransaction> transaction) {
+	vector<SecretEntry> result;
+
+	auto pool_connection = postgres_catalog.GetConnectionPool().GetConnection();
+	auto &connection = pool_connection.GetConnection();
+
+	string query = StringUtil::Format("SELECT secret_name, serialized_secret FROM %s", secrets_table_name);
+	auto query_result = connection.Query(query);
+
+	for (idx_t i = 0; i < query_result->Count(); i++) {
+		auto secret_name = query_result->GetString(i, 0);
+		auto hex_string = query_result->GetString(i, 1);
+
+		auto secret = DeserializeSecret(hex_string, secret_name);
+		if (secret) {
+			SecretEntry entry(std::move(secret));
+			entry.storage_mode = storage_name;
+			entry.persist_type = SecretPersistType::PERSISTENT;
+			result.push_back(std::move(entry));
+		}
+	}
+
+	return result;
+}
+
+void PostgresSecretStorage::DropSecretByName(const string &name, OnEntryNotFound on_entry_not_found,
+                                             optional_ptr<CatalogTransaction> transaction) {
+	// Check if secret exists
+	auto existing = GetSecretByName(name, transaction);
+	if (!existing && on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
+		throw InvalidInputException("Failed to remove non-existent persistent secret '%s' in secret storage '%s'", name,
+		                            storage_name);
+	}
+
+	// Get a connection from the pool
+	auto pool_connection = postgres_catalog.GetConnectionPool().GetConnection();
+	auto &connection = pool_connection.GetConnection();
+
+	// Delete the secret
+	string escaped_name = EscapeSQLString(name);
+	string query = StringUtil::Format("DELETE FROM %s WHERE secret_name = '%s'", secrets_table_name, escaped_name);
+	connection.Execute(query);
+}
+
+SecretMatch PostgresSecretStorage::LookupSecret(const string &path, const string &type,
+                                                optional_ptr<CatalogTransaction> transaction) {
+	auto best_match = SecretMatch();
+
+	auto pool_connection = postgres_catalog.GetConnectionPool().GetConnection();
+	auto &connection = pool_connection.GetConnection();
+
+	string escaped_type = EscapeSQLString(StringUtil::Lower(type));
+	string query = StringUtil::Format("SELECT secret_name, serialized_secret FROM %s WHERE LOWER(secret_type) = '%s'",
+										secrets_table_name, escaped_type);
+	auto query_result = connection.Query(query);
+
+	for (idx_t i = 0; i < query_result->Count(); i++) {
+		auto secret_name = query_result->GetString(i, 0);
+		auto hex_string = query_result->GetString(i, 1);
+
+		auto secret = DeserializeSecret(hex_string, secret_name);
+		if (secret) {
+			SecretEntry entry(std::move(secret));
+			entry.storage_mode = storage_name;
+			entry.persist_type = SecretPersistType::PERSISTENT;
+			best_match = SelectBestMatch(entry, path, tie_break_offset, best_match);
+		}
+	}
+	
+	return best_match;
+}
+
+unique_ptr<SecretEntry> PostgresSecretStorage::GetSecretByName(const string &name,
+                                                                optional_ptr<CatalogTransaction> transaction) {
+	auto pool_connection = postgres_catalog.GetConnectionPool().GetConnection();
+	auto &connection = pool_connection.GetConnection();
+
+	string escaped_name = EscapeSQLString(name);
+	string query = StringUtil::Format("SELECT serialized_secret FROM %s WHERE secret_name = '%s'", secrets_table_name,
+										escaped_name);
+	auto result = connection.Query(query);
+
+	if (result->Count() == 0) {
+		return nullptr;
+	}
+
+	auto hex_string = result->GetString(0, 0);
+	auto secret = DeserializeSecret(hex_string, name);
+	if (!secret) {
+		return nullptr;
+	}
+
+	auto secret_entry = make_uniq<SecretEntry>(std::move(secret));
+	secret_entry->storage_mode = storage_name;
+	secret_entry->persist_type = SecretPersistType::PERSISTENT;
+	return secret_entry;
 }
 
 void PostgresSecretStorage::InitializeSecretsTable() {
@@ -53,7 +255,9 @@ string PostgresSecretStorage::SerializeSecret(const BaseSecret &secret) {
 	// Serialize the secret to a binary format
 	MemoryStream stream;
 	BinarySerializer serializer(stream);
+	serializer.Begin();
 	secret.Serialize(serializer);
+	serializer.End();
 
 	// Encode as PostgreSQL hex format (\\x followed by hex digits)
 	auto data = stream.GetData();
@@ -68,80 +272,6 @@ string PostgresSecretStorage::SerializeSecret(const BaseSecret &secret) {
 	}
 
 	return result;
-}
-
-void PostgresSecretStorage::WriteSecret(const BaseSecret &secret, OnCreateConflict on_conflict) {
-	// Get a connection from the pool
-	auto pool_connection = postgres_catalog.GetConnectionPool().GetConnection();
-	auto &connection = pool_connection.GetConnection();
-
-	// Serialize the secret (returns hex format: \\x...)
-	string serialized = SerializeSecret(secret);
-	string secret_name = secret.GetName();
-	string secret_type = secret.GetType();
-
-	// Escape single quotes in strings for SQL
-	auto escape_sql = [](const string &str) -> string {
-		string result;
-		for (char c : str) {
-			if (c == '\'') {
-				result += "''";
-			} else {
-				result += c;
-			}
-		}
-		return result;
-	};
-
-	string escaped_name = escape_sql(secret_name);
-	string escaped_type = escape_sql(secret_type);
-
-	// Build the INSERT query based on conflict handling
-	// For BYTEA, we use the hex format directly (no quotes around it, just the literal)
-	string query;
-	if (on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
-		query = StringUtil::Format(
-		    "INSERT INTO %s (secret_name, secret_type, serialized_secret) VALUES ('%s', '%s', '%s')",
-		    secrets_table_name, escaped_name, escaped_type, serialized);
-	} else if (on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
-		// Use INSERT ... ON CONFLICT ... DO UPDATE for upsert behavior
-		query = StringUtil::Format(
-		    "INSERT INTO %s (secret_name, secret_type, serialized_secret) VALUES ('%s', '%s', '%s') "
-		    "ON CONFLICT (secret_name) DO UPDATE SET secret_type = EXCLUDED.secret_type, "
-		    "serialized_secret = EXCLUDED.serialized_secret",
-		    secrets_table_name, escaped_name, escaped_type, serialized);
-	} else {
-		// IGNORE_ON_CONFLICT
-		query = StringUtil::Format(
-		    "INSERT INTO %s (secret_name, secret_type, serialized_secret) VALUES ('%s', '%s', '%s') "
-		    "ON CONFLICT (secret_name) DO NOTHING",
-		    secrets_table_name, escaped_name, escaped_type, serialized);
-	}
-
-	connection.Execute(query);
-}
-
-void PostgresSecretStorage::RemoveSecret(const string &secret, OnEntryNotFound on_entry_not_found) {
-	// Get a connection from the pool
-	auto pool_connection = postgres_catalog.GetConnectionPool().GetConnection();
-	auto &connection = pool_connection.GetConnection();
-
-	// Delete the secret
-	auto escape_sql = [](const string &str) -> string {
-		string result;
-		for (char c : str) {
-			if (c == '\'') {
-				result += "''";
-			} else {
-				result += c;
-			}
-		}
-		return result;
-	};
-
-	string escaped_name = escape_sql(secret);
-	string query = StringUtil::Format("DELETE FROM %s WHERE secret_name = '%s'", secrets_table_name, escaped_name);
-	connection.Execute(query);
 }
 
 } // namespace duckdb

--- a/src/postgres_secret_storage.cpp
+++ b/src/postgres_secret_storage.cpp
@@ -1,0 +1,172 @@
+#include "postgres_secret_storage.hpp"
+#include "storage/postgres_catalog.hpp"
+#include "duckdb/main/secret/secret.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/serializer/binary_serializer.hpp"
+#include "duckdb/common/serializer/binary_deserializer.hpp"
+#include "duckdb/common/serializer/memory_stream.hpp"
+#include <atomic>
+
+namespace duckdb {
+
+// Initialize static counters starting at 25 and 0
+std::atomic<int64_t> PostgresSecretStorage::next_tie_break_offset(25);
+std::atomic<int64_t> PostgresSecretStorage::next_unique_id(0);
+
+int64_t PostgresSecretStorage::GetNextTieBreakOffset() {
+	return next_tie_break_offset.fetch_add(1);
+}
+
+PostgresSecretStorage::PostgresSecretStorage(const string &name_p, DatabaseInstance &db,
+                                             PostgresCatalog &postgres_catalog_p)
+    : CatalogSetSecretStorage(db, name_p, GetNextTieBreakOffset()), postgres_catalog(postgres_catalog_p),
+      secrets_table_name("duckdb_secrets") {
+	// Initialize the catalog set for storing secrets
+	secrets = make_uniq<CatalogSet>(Catalog::GetSystemCatalog(db));
+	persistent = true;
+
+	// Create the secrets table if it doesn't exist
+	InitializeSecretsTable();
+}
+
+PostgresSecretStorage::~PostgresSecretStorage() {
+}
+
+void PostgresSecretStorage::InitializeSecretsTable() {
+	// Get a connection from the pool
+	auto pool_connection = postgres_catalog.GetConnectionPool().GetConnection();
+	auto &connection = pool_connection.GetConnection();
+
+	// Create a table to store secrets if it doesn't exist
+	string create_table_query = R"(
+		CREATE TABLE IF NOT EXISTS )" + secrets_table_name + R"( (
+			secret_name VARCHAR PRIMARY KEY,
+			secret_type VARCHAR NOT NULL,
+			serialized_secret BYTEA NOT NULL
+		)
+	)";
+
+	connection.Execute(create_table_query);
+}
+
+string PostgresSecretStorage::SerializeSecret(const BaseSecret &secret) {
+	// Serialize the secret to a binary format
+	MemoryStream stream;
+	BinarySerializer serializer(stream);
+	secret.Serialize(serializer);
+
+	// Encode as PostgreSQL hex format (\\x followed by hex digits)
+	auto data = stream.GetData();
+	auto size = stream.GetPosition();
+	string result = "\\\\x";
+	result.reserve(size * 2 + 3);
+
+	const char *hex_chars = "0123456789abcdef";
+	for (idx_t i = 0; i < size; i++) {
+		result.push_back(hex_chars[(data[i] >> 4) & 0xF]);
+		result.push_back(hex_chars[data[i] & 0xF]);
+	}
+
+	return result;
+}
+
+void PostgresSecretStorage::WriteSecret(const BaseSecret &secret, OnCreateConflict on_conflict) {
+	// Get a connection from the pool
+	auto pool_connection = postgres_catalog.GetConnectionPool().GetConnection();
+	auto &connection = pool_connection.GetConnection();
+
+	// Serialize the secret (returns hex format: \\x...)
+	string serialized = SerializeSecret(secret);
+	string secret_name = secret.GetName();
+	string secret_type = secret.GetType();
+
+	// Escape single quotes in strings for SQL
+	auto escape_sql = [](const string &str) -> string {
+		string result;
+		for (char c : str) {
+			if (c == '\'') {
+				result += "''";
+			} else {
+				result += c;
+			}
+		}
+		return result;
+	};
+
+	string escaped_name = escape_sql(secret_name);
+	string escaped_type = escape_sql(secret_type);
+
+	// Build the INSERT query based on conflict handling
+	// For BYTEA, we use the hex format directly (no quotes around it, just the literal)
+	string query;
+	if (on_conflict == OnCreateConflict::ERROR_ON_CONFLICT) {
+		query = StringUtil::Format(
+		    "INSERT INTO %s (secret_name, secret_type, serialized_secret) VALUES ('%s', '%s', '%s')",
+		    secrets_table_name, escaped_name, escaped_type, serialized);
+	} else if (on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
+		// Use INSERT ... ON CONFLICT ... DO UPDATE for upsert behavior
+		query = StringUtil::Format(
+		    "INSERT INTO %s (secret_name, secret_type, serialized_secret) VALUES ('%s', '%s', '%s') "
+		    "ON CONFLICT (secret_name) DO UPDATE SET secret_type = EXCLUDED.secret_type, "
+		    "serialized_secret = EXCLUDED.serialized_secret",
+		    secrets_table_name, escaped_name, escaped_type, serialized);
+	} else {
+		// IGNORE_ON_CONFLICT
+		query = StringUtil::Format(
+		    "INSERT INTO %s (secret_name, secret_type, serialized_secret) VALUES ('%s', '%s', '%s') "
+		    "ON CONFLICT (secret_name) DO NOTHING",
+		    secrets_table_name, escaped_name, escaped_type, serialized);
+	}
+
+	connection.Execute(query);
+}
+
+void PostgresSecretStorage::RemoveSecret(const string &secret, OnEntryNotFound on_entry_not_found) {
+	// Get a connection from the pool
+	auto pool_connection = postgres_catalog.GetConnectionPool().GetConnection();
+	auto &connection = pool_connection.GetConnection();
+
+	// Check if the secret exists first if we need to throw an error
+	if (on_entry_not_found == OnEntryNotFound::THROW_EXCEPTION) {
+		auto escape_sql = [](const string &str) -> string {
+			string result;
+			for (char c : str) {
+				if (c == '\'') {
+					result += "''";
+				} else {
+					result += c;
+				}
+			}
+			return result;
+		};
+
+		string escaped_name = escape_sql(secret);
+		string check_query = StringUtil::Format("SELECT COUNT(*) FROM %s WHERE secret_name = '%s'",
+		                                        secrets_table_name, escaped_name);
+
+		auto result = connection.Query(check_query);
+		// Parse result to check if secret exists
+		// If count is 0, throw exception
+		// Note: This is a simplified check - you may need to parse the actual result
+	}
+
+	// Delete the secret
+	auto escape_sql = [](const string &str) -> string {
+		string result;
+		for (char c : str) {
+			if (c == '\'') {
+				result += "''";
+			} else {
+				result += c;
+			}
+		}
+		return result;
+	};
+
+	string escaped_name = escape_sql(secret);
+	string query = StringUtil::Format("DELETE FROM %s WHERE secret_name = '%s'", secrets_table_name, escaped_name);
+	connection.Execute(query);
+}
+
+} // namespace duckdb

--- a/src/storage/postgres_catalog.cpp
+++ b/src/storage/postgres_catalog.cpp
@@ -113,9 +113,7 @@ void PostgresCatalog::Initialize(bool load_builtin) {
 	// Create a storage name based on the attached database name
 	string storage_name = "postgres_" + GetAttached().GetName();
 
-	// Try to register the secret storage
-	// If a storage with this name already exists, silently skip registration
-	// This allows the storage to persist across detach/reattach cycles
+	// Register the secret storage
 	try {
 		auto storage = make_uniq<PostgresSecretStorage>(storage_name, db_instance, *this, secret_manager);
 		secret_manager.LoadSecretStorage(std::move(storage));

--- a/src/storage/postgres_catalog.cpp
+++ b/src/storage/postgres_catalog.cpp
@@ -117,8 +117,7 @@ void PostgresCatalog::Initialize(bool load_builtin) {
 	// If a storage with this name already exists, silently skip registration
 	// This allows the storage to persist across detach/reattach cycles
 	try {
-		auto storage =
-			make_uniq<PostgresSecretStorage>(storage_name, db_instance, *this);
+		auto storage = make_uniq<PostgresSecretStorage>(storage_name, db_instance, *this, secret_manager);
 		secret_manager.LoadSecretStorage(std::move(storage));
 	} catch (InvalidConfigurationException &) {
 		// Storage already exists - this is fine, reuse the existing one

--- a/src/storage/postgres_catalog.cpp
+++ b/src/storage/postgres_catalog.cpp
@@ -122,9 +122,6 @@ void PostgresCatalog::Initialize(bool load_builtin) {
 		secret_manager.LoadSecretStorage(std::move(storage));
 	} catch (InvalidConfigurationException &) {
 		// Storage already exists - this is fine, reuse the existing one
-		// Note: The existing storage may have a dangling catalog reference, but
-		// since we only write/remove secrets (not read), and those operations
-		// will fail if the catalog is detached, this is acceptable
 	}
 }
 

--- a/src/storage/postgres_catalog.cpp
+++ b/src/storage/postgres_catalog.cpp
@@ -115,7 +115,7 @@ void PostgresCatalog::Initialize(bool load_builtin) {
 
 	// Register the secret storage
 	try {
-		auto storage = make_uniq<PostgresSecretStorage>(storage_name, db_instance, *this, secret_manager);
+		auto storage = make_uniq<PostgresSecretStorage>(storage_name, *this, secret_manager);
 		secret_manager.LoadSecretStorage(std::move(storage));
 	} catch (InvalidConfigurationException &) {
 		// Storage already exists - this is fine, reuse the existing one

--- a/test/sql/storage/attach_secret_storage.test
+++ b/test/sql/storage/attach_secret_storage.test
@@ -1,0 +1,91 @@
+# name: test/sql/storage/attach_secret_storage.test
+# description: Test storing secrets in postgres database
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+# Attach postgres database
+statement ok
+ATTACH 'dbname=postgresscanner' AS pg (TYPE POSTGRES)
+
+# Load httpfs for S3 secret type
+statement ok
+INSTALL httpfs
+
+statement ok
+LOAD httpfs
+
+# Create a secret explicitly in postgres storage
+statement ok
+CREATE SECRET test_s3_secret IN postgres_pg (
+	TYPE S3,
+	KEY_ID 'test_key_id',
+	SECRET 'test_secret_value',
+	REGION 'us-east-1'
+)
+
+# Verify the secret appears in duckdb_secrets with correct storage
+query III
+SELECT name, type, storage FROM duckdb_secrets() WHERE name='test_s3_secret' ORDER BY name
+----
+test_s3_secret	s3	postgres_pg
+
+# Verify the secret was written to postgres by checking via postgres_query
+query II
+SELECT secret_name, secret_type FROM postgres_query('pg', 'SELECT secret_name, secret_type FROM duckdb_secrets WHERE secret_name = ''test_s3_secret''')
+----
+test_s3_secret	s3
+
+# Create another secret in postgres storage
+statement ok
+CREATE SECRET another_secret IN postgres_pg (
+	TYPE S3,
+	KEY_ID 'another_key',
+	SECRET 'another_value'
+)
+
+# Verify both secrets exist
+query I
+SELECT COUNT(*) FROM duckdb_secrets() WHERE storage='postgres_pg'
+----
+2
+
+# Drop a secret from postgres storage
+statement ok
+DROP SECRET test_s3_secret FROM postgres_pg
+
+# Verify it was removed
+query I
+SELECT COUNT(*) FROM duckdb_secrets() WHERE name='test_s3_secret'
+----
+0
+
+# Verify it was removed from postgres
+query I
+SELECT COUNT(*) FROM postgres_query('pg', 'SELECT * FROM duckdb_secrets WHERE secret_name = ''test_s3_secret''')
+----
+0
+
+# The other secret should still exist
+query III
+SELECT name, type, storage FROM duckdb_secrets() WHERE name='another_secret'
+----
+another_secret	s3	postgres_pg
+
+# Clean up
+statement ok
+DROP SECRET another_secret FROM postgres_pg
+
+# Verify duckdb_secrets table is empty in postgres
+query I
+SELECT COUNT(*) FROM postgres_query('pg', 'SELECT * FROM duckdb_secrets')
+----
+0
+
+statement ok
+DETACH pg

--- a/test/sql/storage/attach_secret_storage.test
+++ b/test/sql/storage/attach_secret_storage.test
@@ -9,6 +9,16 @@ require-env POSTGRES_TEST_DATABASE_AVAILABLE
 statement ok
 PRAGMA enable_verification
 
+# Clean up any leftover secrets from previous test runs by attaching, dropping table, and reattaching
+statement ok
+ATTACH 'dbname=postgresscanner' AS pg_cleanup (TYPE POSTGRES)
+
+statement ok
+CALL postgres_execute('pg_cleanup', 'DROP TABLE IF EXISTS duckdb_secrets')
+
+statement ok
+DETACH pg_cleanup
+
 # Attach postgres database
 statement ok
 ATTACH 'dbname=postgresscanner' AS pg (TYPE POSTGRES)
@@ -89,3 +99,49 @@ SELECT COUNT(*) FROM postgres_query('pg', 'SELECT * FROM duckdb_secrets')
 
 statement ok
 DETACH pg
+
+# Test reading secrets after detach and reattach
+statement ok
+ATTACH 'dbname=postgresscanner' AS pg2 (TYPE POSTGRES)
+
+# Create a secret for persistence test
+statement ok
+CREATE SECRET persistent_secret IN postgres_pg2 (
+	TYPE S3,
+	KEY_ID 'persistent_key',
+	SECRET 'persistent_secret',
+	REGION 'us-west-2'
+)
+
+# Verify it exists
+query III
+SELECT name, type, storage FROM duckdb_secrets() WHERE name='persistent_secret'
+----
+persistent_secret	s3	postgres_pg2
+
+# Detach the database
+statement ok
+DETACH pg2
+
+# Reattach - this should load the secret from postgres
+statement ok
+ATTACH 'dbname=postgresscanner' AS pg3 (TYPE POSTGRES)
+
+# Verify the secret is still accessible after reattach (tests read functionality)
+query III
+SELECT name, type, storage FROM duckdb_secrets() WHERE name='persistent_secret'
+----
+persistent_secret	s3	postgres_pg3
+
+# Clean up
+statement ok
+DROP SECRET persistent_secret FROM postgres_pg3
+
+# Verify it was removed
+query I
+SELECT COUNT(*) FROM duckdb_secrets() WHERE name='persistent_secret'
+----
+0
+
+statement ok
+DETACH pg3


### PR DESCRIPTION
The goal is to store the secrets in postgres so they can be retrieved remotely and automatically when attaching a lake. For example, the initial configuration is:
```
ATTACH 'postgres:postgresql://user:password@host/lake' AS metadata;
ATTACH 'ducklake:postgres:postgresql://user:password@host/lake' AS lake (DATA_PATH 's3://some-bucket');
CREATE SECRET IN postgres_metadata (
	TYPE S3,
	KEY_ID 'test_key_id',
	SECRET 'test_secret_value',
	REGION 'us-east-1'
);
```
After which, duckdb can be run in the JDBC driver for BI tools with a connection string like this, and it will be able to connect to postgres and S3 without further configuration:
```
jdbc:duckdb:ducklake:postgres:postgresql://user:password@host/lake
```
Feedback appreciated!