### PR TITLE
Add format check job to CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,34 @@
+---
+BasedOnStyle: LLVM
+SortIncludes: false
+TabWidth: 4
+IndentWidth: 4
+ColumnLimit: 120
+AllowShortFunctionsOnASingleLine: false
+---
+UseTab: ForIndentation
+DerivePointerAlignment: false
+PointerAlignment: Right
+AlignConsecutiveMacros: true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AlignAfterOpenBracket: Align
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+AllowShortLambdasOnASingleLine: Inline
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: Yes
+IncludeBlocks: Regroup
+Language: Cpp
+AccessModifierOffset: -4
+KeepEmptyLinesAtTheStartOfBlocks: false
+---
+Language: Java
+SpaceAfterCStyleCast: true
+---

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -1,15 +1,45 @@
 name: Integration Tests
-on: [push, pull_request,repository_dispatch]
+on: 
+  push:
+    paths-ignore:
+      - '**.md'
+      - '.github/workflows/**'
+      - '!.github/workflows/Linux.yml'
+  pull_request:
+  repository_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
   cancel-in-progress: true
-defaults:
-  run:
-    shell: bash
 
 jobs:
+
+  format-check:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Install
+        run: |
+          pip3 install           \
+            black==25.1.0        \
+            clang_format==11.0.1 \
+            cmake-format==0.6.13
+
+      - name: Format Check
+        run: |
+          python -m pip show black
+          python -m pip show cmake_format
+          python -m pip show clang_format
+          clang-format --version
+          clang-format --dump-config
+          make format-check
+
   linux-tests-postgres:
     name: Run tests on Linux
+    needs: format-check
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -4,6 +4,10 @@
 name: Main Extension Distribution Pipeline
 on:
   push:
+    paths-ignore:
+      - '**.md'
+      - '.github/workflows/**'
+      - '!.github/workflows/MainDistributionPipeline.yml'
   pull_request:
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@ cmake-build-debug
 .idea
 .DS_Store
 postgres/postgres
-.clang-format
 postgres

--- a/src/postgres_attach.cpp
+++ b/src/postgres_attach.cpp
@@ -20,7 +20,6 @@ struct AttachFunctionData : public TableFunctionData {
 
 static unique_ptr<FunctionData> AttachBind(ClientContext &context, TableFunctionBindInput &input,
                                            vector<LogicalType> &return_types, vector<string> &names) {
-
 	auto result = make_uniq<AttachFunctionData>();
 	result->dsn = input.inputs[0].GetValue<string>();
 

--- a/src/storage/postgres_clear_cache.cpp
+++ b/src/storage/postgres_clear_cache.cpp
@@ -14,7 +14,6 @@ struct ClearCacheFunctionData : public TableFunctionData {
 
 static unique_ptr<FunctionData> ClearCacheBind(ClientContext &context, TableFunctionBindInput &input,
                                                vector<LogicalType> &return_types, vector<string> &names) {
-
 	auto result = make_uniq<ClearCacheFunctionData>();
 	return_types.push_back(LogicalType::BOOLEAN);
 	names.emplace_back("Success");


### PR DESCRIPTION
This PR adds `make format-check` run to CI. It checks-in the `.clang-format` file from the main repo.

Additionally it disables the CI runs for workflow-only changes.