### PR TITLE
Fix flaky pool test

### DIFF
--- a/test/sql/storage/attach_connection_pool.test
+++ b/test/sql/storage/attach_connection_pool.test
@@ -70,19 +70,22 @@ statement ok
 DETACH s
 
 statement ok
+SET pg_pool_enable_thread_local_cache = FALSE
+
+statement ok
 ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES);
 
 statement ok
 USE s;
 
-statement ok
-FROM postgres_configure_pool(catalog_name='s', enable_thread_local_cache=FALSE)
-
 query III
 SELECT catalog_name, available_connections, thread_local_cache_enabled
 FROM postgres_configure_pool(catalog_name='s')
 ----
-s	0	FALSE
+s	1	FALSE
+
+statement ok
+RESET pg_pool_enable_thread_local_cache
 
 statement ok
 SELECT catalog_name, health_check_query


### PR DESCRIPTION
Intermittent CI failure example

```
1. test/sql/storage/attach_connection_pool.test:81
================================================================================
Wrong result in query! (test/sql/storage/attach_connection_pool.test:81)!
================================================================================
SELECT catalog_name, available_connections, thread_local_cache_enabled
FROM postgres_configure_pool(catalog_name='s');
================================================================================
Mismatch on row 1, column available_connections(index 2)
1 <> 0
================================================================================
Expected result:
================================================================================
s	0	FALSE

================================================================================
Actual result:
================================================================================
s	1	0
```

Run: https://github.com/duckdb/duckdb-postgres/actions/runs/24059225425/job/70172331831