### PR TITLE
Don't rollback on reset if not necessary

### DIFF
--- a/src/postgres_connection.cpp
+++ b/src/postgres_connection.cpp
@@ -207,7 +207,8 @@ void PostgresConnection::Reset(const std::string &health_check_query) {
 		throw InternalException("Cannot reset a connection that is not open");
 	}
 	PGconn *conn = GetConn();
-	{
+	auto tx_status = PQtransactionStatus(conn);
+	if (tx_status == PQTRANS_INTRANS || tx_status == PQTRANS_INERROR) {
 		PGresult *res = PQexec(conn, "ROLLBACK");
 		PostgresResult res_holder(res);
 	}


### PR DESCRIPTION
After starting to use the new pooling mechanism we observed an increased amount of rollbacks and warning messages about issuing a rollback outside of a transaction.

My diagnostic is that this behavior is caused by the unconditional ROLLBACK in the `Reset` of the connection, which is called on its release.