### PR TITLE
Pool: support configuring acquire mode

### DIFF
--- a/src/include/storage/postgres_connection_pool.hpp
+++ b/src/include/storage/postgres_connection_pool.hpp
@@ -24,6 +24,8 @@ class PostgresConnectionPool;
 
 using PostgresPoolConnection = dbconnector::pool::PooledConnection<PostgresConnection>;
 
+enum class PostgresPoolAcquireMode { FORCE, WAIT, TRY };
+
 class PostgresConnectionPool : public dbconnector::pool::ConnectionPool<PostgresConnection> {
 public:
 	PostgresConnectionPool(PostgresCatalog &postgres_catalog, ClientContext &context);
@@ -36,9 +38,14 @@ public:
 
 	std::string GetHealthCheckQuery();
 	void SetHealthCheckQuery(const std::string &query);
+	PostgresPoolAcquireMode GetAcquireMode();
+	void SetAcquireMode(PostgresPoolAcquireMode mode);
 
 	static idx_t DefaultPoolSize();
 	static std::string DefaultHealthCheckQuery();
+	static PostgresPoolAcquireMode AcquireModeFromString(const std::string &mode_str);
+	static std::string AcquireModeToString(PostgresPoolAcquireMode mode);
+	static void ValidatePoolAcquireMode(ClientContext &context, SetScope scope, Value &parameter);
 
 protected:
 	std::unique_ptr<PostgresConnection> CreateNewConnection() override;
@@ -50,6 +57,9 @@ private:
 
 	std::mutex config_mutex;
 	std::string health_check_query;
+	PostgresPoolAcquireMode acquire_mode = PostgresPoolAcquireMode::FORCE;
+
+	bool PoolEnabled();
 };
 
 class PostgresConfigurePoolFunction : public TableFunction {

--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -242,6 +242,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          "Postgres idle in transaction timeout in milliseconds to set on scan connections",
 	                          LogicalType::UINTEGER, Value());
 	// connection pool options
+	config.AddExtensionOption(
+	    "pg_pool_acquire_mode",
+	    "How to acquire connections from the pool: 'force' (always connect, ignore pool limit), "
+	    "'wait' (block until available), 'try' (fail immediately if unavailable) (default: force)",
+	    LogicalType::VARCHAR, Value("force"), PostgresConnectionPool::ValidatePoolAcquireMode);
 	config.AddExtensionOption("pg_pool_max_connections",
 	                          "Maximum number of connections that are allowed to be cached in a connection pool for "
 	                          "each attached Postgres database. "

--- a/src/storage/postgres_configure_pool.cpp
+++ b/src/storage/postgres_configure_pool.cpp
@@ -15,6 +15,7 @@ enum class ExecState { UNINITIALIZED, EXHAUSTED };
 
 struct ConfigurePoolBindData : public TableFunctionData {
 	std::pair<std::string, bool> catalog_name;
+	std::pair<PostgresPoolAcquireMode, bool> acquire_mode;
 	std::pair<uint64_t, bool> max_connections;
 	std::pair<uint64_t, bool> wait_timeout_millis;
 	std::pair<bool, bool> enable_thread_local_cache;
@@ -58,8 +59,23 @@ struct ConfigurePoolBindData : public TableFunctionData {
 		return std::make_pair(flag, false);
 	}
 
+	static std::pair<PostgresPoolAcquireMode, bool> LookupAcquireMode(const named_parameter_map_t &map,
+	                                                                  const std::string &key) {
+		std::pair<std::string, bool> st_pair = LookupString(map, key);
+		if (st_pair.second) {
+			return std::make_pair(PostgresPoolAcquireMode::FORCE, true);
+		}
+		try {
+			PostgresPoolAcquireMode mode = PostgresConnectionPool::AcquireModeFromString(st_pair.first);
+			return std::make_pair(mode, false);
+		} catch (InvalidInputException &e) {
+			throw BinderException(e.what());
+		}
+	}
+
 	ConfigurePoolBindData(const named_parameter_map_t &map)
-	    : catalog_name(LookupString(map, "catalog_name")), max_connections(LookupUBigInt(map, "max_connections")),
+	    : catalog_name(LookupString(map, "catalog_name")), acquire_mode(LookupAcquireMode(map, "acquire_mode")),
+	      max_connections(LookupUBigInt(map, "max_connections")),
 	      wait_timeout_millis(LookupUBigInt(map, "wait_timeout_millis")),
 	      enable_thread_local_cache(LookupBool(map, "enable_thread_local_cache")),
 	      max_lifetime_millis(LookupUBigInt(map, "max_lifetime_millis")),
@@ -67,9 +83,9 @@ struct ConfigurePoolBindData : public TableFunctionData {
 	      enable_reaper_thread(LookupBool(map, "enable_reaper_thread")),
 	      health_check_query(LookupString(map, "health_check_query")) {
 		if (catalog_name.second &&
-		    !(max_connections.second && wait_timeout_millis.second && enable_thread_local_cache.second &&
-		      max_lifetime_millis.second && idle_timeout_millis.second && enable_reaper_thread.second &&
-		      health_check_query.second)) {
+		    !(acquire_mode.second && max_connections.second && wait_timeout_millis.second &&
+		      enable_thread_local_cache.second && max_lifetime_millis.second && idle_timeout_millis.second &&
+		      enable_reaper_thread.second && health_check_query.second)) {
 			throw BinderException("'catalog_name' argument must be specified to change any option value on the "
 			                      "connection pool of this catalog");
 		}
@@ -93,6 +109,7 @@ static void AddColumn(vector<LogicalType> &return_types, vector<string> &names, 
 static unique_ptr<FunctionData> ConfigurePoolBind(ClientContext &context, TableFunctionBindInput &input,
                                                   vector<LogicalType> &return_types, vector<string> &names) {
 	AddColumn(return_types, names, "catalog_name", LogicalType::VARCHAR);
+	AddColumn(return_types, names, "acquire_mode", LogicalType::VARCHAR);
 	AddColumn(return_types, names, "available_connections", LogicalType::UBIGINT);
 	AddColumn(return_types, names, "max_connections", LogicalType::UBIGINT);
 	AddColumn(return_types, names, "wait_timeout_millis", LogicalType::UBIGINT);
@@ -143,9 +160,16 @@ static void ConfigurePoolFunction(ClientContext &context, TableFunctionInput &in
 		pools.emplace_back(std::move(pool));
 	}
 
+	if (!bdata.catalog_name.second && pools.size() == 0) {
+		throw InvalidInputException("Catalog not found, name: '%s'", bdata.catalog_name.first);
+	}
+
 	// configure the single pool if specified
 	if (!bdata.catalog_name.second && pools.size() > 0) {
 		auto &pool = pools.at(0);
+		if (!bdata.acquire_mode.second) {
+			pool->SetAcquireMode(bdata.acquire_mode.first);
+		}
 		if (!bdata.max_connections.second) {
 			pool->SetMaxConnections(bdata.max_connections.first);
 		}
@@ -178,6 +202,7 @@ static void ConfigurePoolFunction(ClientContext &context, TableFunctionInput &in
 	for (auto &pool : pools) {
 		idx_t col_idx = 0;
 		output.SetValue(col_idx++, row_idx, Value(cat_names.at(row_idx)));
+		output.SetValue(col_idx++, row_idx, Value(PostgresConnectionPool::AcquireModeToString(pool->GetAcquireMode())));
 		output.SetValue(col_idx++, row_idx, Value::UBIGINT(pool->GetAvailableConnections()));
 		output.SetValue(col_idx++, row_idx, Value::UBIGINT(pool->GetMaxConnections()));
 		output.SetValue(col_idx++, row_idx, Value::UBIGINT(pool->GetWaitTimeoutMillis()));
@@ -199,6 +224,7 @@ PostgresConfigurePoolFunction::PostgresConfigurePoolFunction()
     : TableFunction("postgres_configure_pool", std::vector<LogicalType>(), ConfigurePoolFunction, ConfigurePoolBind,
                     ConfigurePoolInitGlobalState, ConfigurePoolInitLocalState) {
 	named_parameters["catalog_name"] = LogicalType::VARCHAR;
+	named_parameters["acquire_mode"] = LogicalType::VARCHAR;
 	named_parameters["max_connections"] = LogicalType::UBIGINT;
 	named_parameters["wait_timeout_millis"] = LogicalType::UBIGINT;
 	named_parameters["enable_thread_local_cache"] = LogicalType::BOOLEAN;

--- a/src/storage/postgres_connection_pool.cpp
+++ b/src/storage/postgres_connection_pool.cpp
@@ -19,9 +19,17 @@ static std::string GetHealthCheckQueryFromConfig(ClientContext &context) {
 	return PostgresConnectionPool::DefaultHealthCheckQuery();
 }
 
+static PostgresPoolAcquireMode GetAcquireModeFromConfig(ClientContext &context) {
+	Value mode_val;
+	if (context.TryGetCurrentSetting("pg_pool_acquire_mode", mode_val)) {
+		return PostgresConnectionPool::AcquireModeFromString(mode_val.ToString());
+	}
+	return PostgresPoolAcquireMode::FORCE;
+}
+
 PostgresConnectionPool::PostgresConnectionPool(PostgresCatalog &postgres_catalog, ClientContext &context)
     : dbconnector::pool::ConnectionPool<PostgresConnection>(CreateConfig(context)), postgres_catalog(postgres_catalog),
-      health_check_query(GetHealthCheckQueryFromConfig(context)) {
+      health_check_query(GetHealthCheckQueryFromConfig(context)), acquire_mode(GetAcquireModeFromConfig(context)) {
 }
 
 PostgresPoolConnection PostgresConnectionPool::ForceGetConnection() {
@@ -29,8 +37,7 @@ PostgresPoolConnection PostgresConnectionPool::ForceGetConnection() {
 }
 
 bool PostgresConnectionPool::TryGetConnection(PostgresPoolConnection &connection) {
-	bool pool_enabled = GetMaxConnections() > 0;
-	PostgresPoolConnection acquired = pool_enabled ? TryAcquire() : ForceAcquire();
+	PostgresPoolConnection acquired = PoolEnabled() ? TryAcquire() : ForceAcquire();
 	if (!acquired) {
 		return false;
 	}
@@ -39,8 +46,20 @@ bool PostgresConnectionPool::TryGetConnection(PostgresPoolConnection &connection
 }
 
 PostgresPoolConnection PostgresConnectionPool::GetConnection() {
-	bool pool_enabled = GetMaxConnections() > 0;
-	return pool_enabled ? WaitAcquire() : ForceAcquire();
+	if (!PoolEnabled()) {
+		return ForceAcquire();
+	}
+	PostgresPoolAcquireMode mode = GetAcquireMode();
+	switch (mode) {
+	case PostgresPoolAcquireMode::FORCE:
+		return ForceAcquire();
+	case PostgresPoolAcquireMode::WAIT:
+		return WaitAcquire();
+	case PostgresPoolAcquireMode::TRY:
+		return TryAcquire();
+	default:
+		throw IOException("Invalid unsupported acquire mode: %d" + static_cast<int>(mode));
+	}
 }
 
 std::unique_ptr<PostgresConnection> PostgresConnectionPool::CreateNewConnection() {
@@ -69,6 +88,16 @@ std::string PostgresConnectionPool::GetHealthCheckQuery() {
 void PostgresConnectionPool::SetHealthCheckQuery(const std::string &query) {
 	std::lock_guard<std::mutex> guard(config_mutex);
 	this->health_check_query = std::string(query.data(), query.length());
+}
+
+PostgresPoolAcquireMode PostgresConnectionPool::GetAcquireMode() {
+	std::lock_guard<std::mutex> guard(config_mutex);
+	return acquire_mode;
+}
+
+void PostgresConnectionPool::SetAcquireMode(PostgresPoolAcquireMode mode) {
+	std::lock_guard<std::mutex> guard(config_mutex);
+	this->acquire_mode = mode;
 }
 
 idx_t PostgresConnectionPool::DefaultPoolSize() {
@@ -122,6 +151,51 @@ static dbconnector::pool::ConnectionPoolConfig CreateConfig(ClientContext &ctx) 
 	}
 
 	return config;
+}
+
+bool PostgresConnectionPool::PoolEnabled() {
+	return GetMaxConnections() > 0;
+}
+
+PostgresPoolAcquireMode PostgresConnectionPool::AcquireModeFromString(const std::string &mode_str) {
+	auto ms = StringUtil::Lower(mode_str);
+	if (ms == "force") {
+		return PostgresPoolAcquireMode::FORCE;
+	} else if (ms == "wait") {
+		return PostgresPoolAcquireMode::WAIT;
+	} else if (ms == "try") {
+		return PostgresPoolAcquireMode::TRY;
+	} else {
+		throw InvalidInputException("Invalid unsupported acquire mode: '%s'", mode_str);
+	}
+}
+
+std::string PostgresConnectionPool::AcquireModeToString(PostgresPoolAcquireMode mode) {
+	switch (mode) {
+	case PostgresPoolAcquireMode::FORCE:
+		return "force";
+	case PostgresPoolAcquireMode::WAIT:
+		return "wait";
+	case PostgresPoolAcquireMode::TRY:
+		return "try";
+	default:
+		throw InvalidInputException("Invalid unsupported acquire mode: %d" + static_cast<int>(mode));
+	}
+}
+
+void PostgresConnectionPool::ValidatePoolAcquireMode(ClientContext &context, SetScope scope, Value &parameter) {
+	PostgresPoolAcquireMode mode = AcquireModeFromString(parameter.ToString());
+	if (mode != PostgresPoolAcquireMode::FORCE) {
+		Value pool_size_val;
+		if (context.TryGetCurrentSetting("pg_pool_max_connections", pool_size_val)) {
+			auto pool_size = pool_size_val.GetValue<uint64_t>();
+			if (pool_size == 0) {
+				std::string mode_str = AcquireModeToString(mode);
+				throw InvalidInputException(
+				    "pg_pool_pool_acquire_mode='%s' requires pg_pool_max_connections > 0 (pooling enabled)", mode_str);
+			}
+		}
+	}
 }
 
 } // namespace duckdb

--- a/test/sql/storage/attach_connection_pool_configure.test
+++ b/test/sql/storage/attach_connection_pool_configure.test
@@ -20,11 +20,23 @@ ORDER BY catalog_name
 s
 s1
 
-query I
-SELECT catalog_name
+query II
+SELECT catalog_name, acquire_mode
 FROM postgres_configure_pool(catalog_name='s')
 ----
+s	force
+
+query I
+SELECT catalog_name
+FROM postgres_configure_pool(catalog_name='s', acquire_mode='wait')
+----
 s
+
+query II
+SELECT catalog_name, acquire_mode
+FROM postgres_configure_pool(catalog_name='s')
+----
+s	wait
 
 query I
 SELECT catalog_name
@@ -122,6 +134,11 @@ statement error
 FROM postgres_configure_pool(max_connections=42)
 ----
 'catalog_name' argument must be specified
+
+statement error
+FROM postgres_configure_pool(catalog_name='fail', max_connections=42)
+----
+Catalog not found
 
 statement ok
 DETACH s1

--- a/test/sql/storage/attach_connection_pool_options.test
+++ b/test/sql/storage/attach_connection_pool_options.test
@@ -13,6 +13,47 @@ statement ok
 DETACH s
 
 statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES);
+
+query II
+SELECT catalog_name, acquire_mode 
+FROM postgres_configure_pool(catalog_name='s')
+----
+s	force
+
+statement ok
+DETACH s
+
+statement ok
+SET pg_pool_max_connections = 0
+
+statement error
+SET pg_pool_acquire_mode = 'wait'
+----
+pg_pool_max_connections > 0
+
+statement ok
+RESET pg_pool_max_connections
+
+statement ok
+SET pg_pool_acquire_mode = 'try'
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES);
+
+query II
+SELECT catalog_name, acquire_mode 
+FROM postgres_configure_pool(catalog_name='s')
+----
+s	try
+
+statement ok
+RESET pg_pool_acquire_mode
+
+statement ok
+DETACH s
+
+statement ok
 SET pg_pool_max_connections = 42
 
 statement ok


### PR DESCRIPTION
This PR adds new configuration option:

 - `pg_pool_acquire_mode` (`VARCHAR`, default: 'force'): how to acquire connections from the pool: 'force' (always connect, ignore pool limit), 'wait' (block until available), 'try' (fail immediately if unavailable)

This option is only applied to Postgres databases attached after the option is set.

To configure it for a Postgres database that is already attached, the `acquire_mode` named parameter is also added to
`postgres_configure_pool()` function:

```sql
FROM postgres_configure_pool(catalog_name='my_db', acquire_mode='wait')
```

Note, before this option the default pool behaviour was `wait`, now the default behaviour is changed to `force`.