### PR TITLE
Make connection pool options GLOBAL

### DIFF
--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -246,25 +246,28 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    "pg_pool_acquire_mode",
 	    "How to acquire connections from the pool: 'force' (always connect, ignore pool limit), "
 	    "'wait' (block until available), 'try' (fail immediately if unavailable) (default: force)",
-	    LogicalType::VARCHAR, Value("force"), PostgresConnectionPool::ValidatePoolAcquireMode);
+	    LogicalType::VARCHAR, Value("force"), PostgresConnectionPool::ValidatePoolAcquireMode, SetScope::GLOBAL);
 	config.AddExtensionOption("pg_pool_max_connections",
 	                          "Maximum number of connections that are allowed to be cached in a connection pool for "
 	                          "each attached Postgres database. "
 	                          "This number can be temporary exceeded when parallel scans are used. " +
 	                              CreatePoolNote("max_connections=42"),
-	                          LogicalType::UBIGINT, Value::UBIGINT(PostgresConnectionPool::DefaultPoolSize()));
+	                          LogicalType::UBIGINT, Value::UBIGINT(PostgresConnectionPool::DefaultPoolSize()), nullptr,
+	                          SetScope::GLOBAL);
 	config.AddExtensionOption("pg_pool_wait_timeout_millis",
 	                          "Maximum number of milliseconds to wait when acquiring a connection from a pool where "
 	                          "all available connections are already taken. " +
 	                              CreatePoolNote("wait_timeout_millis=60000"),
 	                          LogicalType::UBIGINT,
-	                          Value::UBIGINT(dbconnector::pool::ConnectionPoolConfig().wait_timeout_millis));
+	                          Value::UBIGINT(dbconnector::pool::ConnectionPoolConfig().wait_timeout_millis), nullptr,
+	                          SetScope::GLOBAL);
 	config.AddExtensionOption(
 	    "pg_pool_enable_thread_local_cache",
 	    "Whether to enable the connection caching in thread-local cache. Such connections are getting pinned to the "
 	    "threads and are not made available to other threads, while still taking the place in the pool. " +
 	        CreatePoolNote("enable_thread_local_cache=FALSE"),
-	    LogicalType::BOOLEAN, Value::BOOLEAN(dbconnector::pool::ConnectionPoolConfig().tl_cache_enabled));
+	    LogicalType::BOOLEAN, Value::BOOLEAN(dbconnector::pool::ConnectionPoolConfig().tl_cache_enabled), nullptr,
+	    SetScope::GLOBAL);
 	config.AddExtensionOption("pg_pool_max_lifetime_millis",
 	                          "Maximum number of milliseconds the connection can be kept open. This number is checked "
 	                          "when the connection is taken from the pool and returned to the pool. "
@@ -272,7 +275,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          "option), then this number is checked in background periodically. " +
 	                              CreatePoolNote("max_lifetime_millis=600000"),
 	                          LogicalType::UBIGINT,
-	                          Value::UBIGINT(dbconnector::pool::ConnectionPoolConfig().max_lifetime_millis));
+	                          Value::UBIGINT(dbconnector::pool::ConnectionPoolConfig().max_lifetime_millis), nullptr,
+	                          SetScope::GLOBAL);
 	config.AddExtensionOption("pg_pool_idle_timeout_millis",
 	                          "Maximum number of milliseconds the connection can be kept idle in the pool. This number "
 	                          "is checked when the connection is taken from the pool. "
@@ -280,7 +284,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          "option), then this number is checked in background periodically. " +
 	                              CreatePoolNote("idle_timeout_millis=300000"),
 	                          LogicalType::UBIGINT,
-	                          Value::UBIGINT(dbconnector::pool::ConnectionPoolConfig().idle_timeout_millis));
+	                          Value::UBIGINT(dbconnector::pool::ConnectionPoolConfig().idle_timeout_millis), nullptr,
+	                          SetScope::GLOBAL);
 	config.AddExtensionOption(
 	    "pg_pool_enable_reaper_thread",
 	    "Whether to enable the connection pool reaper thread, that periodically scans the pool to check the "
@@ -288,12 +293,14 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    "Either 'max_lifetime_millis' or 'idle_timeout_millis' must be set to a non-zero value for this option to be "
 	    "effective. " +
 	        CreatePoolNote("enable_reaper_thread=TRUE"),
-	    LogicalType::BOOLEAN, Value::BOOLEAN(dbconnector::pool::ConnectionPoolConfig().start_reaper_thread));
+	    LogicalType::BOOLEAN, Value::BOOLEAN(dbconnector::pool::ConnectionPoolConfig().start_reaper_thread), nullptr,
+	    SetScope::GLOBAL);
 	config.AddExtensionOption("pg_pool_health_check_query",
 	                          "The query that is used to check that the connection is healthy. Setting this option to "
 	                          "an empty string disables the health check. " +
 	                              CreatePoolNote("health_check_query=SELECT 42"),
-	                          LogicalType::VARCHAR, PostgresConnectionPool::DefaultHealthCheckQuery());
+	                          LogicalType::VARCHAR, PostgresConnectionPool::DefaultHealthCheckQuery(), nullptr,
+	                          SetScope::GLOBAL);
 
 	OptimizerExtension postgres_optimizer;
 	postgres_optimizer.optimize_function = PostgresOptimizer::Optimize;

--- a/src/storage/postgres_connection_pool.cpp
+++ b/src/storage/postgres_connection_pool.cpp
@@ -102,8 +102,9 @@ void PostgresConnectionPool::SetAcquireMode(PostgresPoolAcquireMode mode) {
 
 idx_t PostgresConnectionPool::DefaultPoolSize() {
 	idx_t detected = static_cast<idx_t>(std::thread::hardware_concurrency());
+	idx_t detected_adjusted = detected * 3 / 2;
 	idx_t default_num = static_cast<idx_t>(8);
-	return detected > default_num ? detected : default_num;
+	return detected_adjusted > default_num ? detected_adjusted : default_num;
 }
 
 std::string PostgresConnectionPool::DefaultHealthCheckQuery() {

--- a/test/sql/storage/attach_connection_pool.test
+++ b/test/sql/storage/attach_connection_pool.test
@@ -85,7 +85,7 @@ FROM postgres_configure_pool(catalog_name='s')
 s	1	FALSE
 
 statement ok
-RESET pg_pool_enable_thread_local_cache
+RESET GLOBAL pg_pool_enable_thread_local_cache
 
 statement ok
 SELECT catalog_name, health_check_query

--- a/test/sql/storage/attach_connection_pool_options.test
+++ b/test/sql/storage/attach_connection_pool_options.test
@@ -33,7 +33,7 @@ SET pg_pool_acquire_mode = 'wait'
 pg_pool_max_connections > 0
 
 statement ok
-RESET pg_pool_max_connections
+RESET GLOBAL pg_pool_max_connections
 
 statement ok
 SET pg_pool_acquire_mode = 'try'
@@ -48,7 +48,7 @@ FROM postgres_configure_pool(catalog_name='s')
 s	try
 
 statement ok
-RESET pg_pool_acquire_mode
+RESET GLOBAL pg_pool_acquire_mode
 
 statement ok
 DETACH s
@@ -66,7 +66,7 @@ FROM postgres_configure_pool(catalog_name='s')
 s	42
 
 statement ok
-RESET pg_pool_max_connections
+RESET GLOBAL pg_pool_max_connections
 
 statement ok
 DETACH s
@@ -84,7 +84,7 @@ FROM postgres_configure_pool(catalog_name='s')
 s	42000
 
 statement ok
-RESET pg_pool_wait_timeout_millis
+RESET GLOBAL pg_pool_wait_timeout_millis
 
 statement ok
 DETACH s
@@ -102,7 +102,7 @@ FROM postgres_configure_pool(catalog_name='s')
 s	FALSE
 
 statement ok
-RESET pg_pool_enable_thread_local_cache
+RESET GLOBAL pg_pool_enable_thread_local_cache
 
 statement ok
 DETACH s
@@ -120,7 +120,7 @@ FROM postgres_configure_pool(catalog_name='s')
 s	42000
 
 statement ok
-RESET pg_pool_max_lifetime_millis
+RESET GLOBAL pg_pool_max_lifetime_millis
 
 statement ok
 DETACH s
@@ -138,7 +138,7 @@ FROM postgres_configure_pool(catalog_name='s')
 s	42000
 
 statement ok
-RESET pg_pool_idle_timeout_millis
+RESET GLOBAL pg_pool_idle_timeout_millis
 
 statement ok
 DETACH s
@@ -159,10 +159,10 @@ FROM postgres_configure_pool(catalog_name='s')
 s	TRUE
 
 statement ok
-RESET pg_pool_enable_reaper_thread
+RESET GLOBAL pg_pool_enable_reaper_thread
 
 statement ok
-RESET pg_pool_idle_timeout_millis
+RESET GLOBAL pg_pool_idle_timeout_millis
 
 statement ok
 DETACH s
@@ -187,7 +187,7 @@ SELECT current_setting('pg_pool_max_connections')
 42
 
 statement ok
-RESET pg_connection_limit
+RESET GLOBAL pg_connection_limit
 
 query I
 SELECT current_setting('pg_pool_max_connections')
@@ -215,7 +215,7 @@ SELECT current_setting('pg_pool_max_connections')
 0
 
 statement ok
-RESET pg_connection_cache
+RESET GLOBAL pg_connection_cache
 
 query I
 SELECT current_setting('pg_pool_max_connections')


### PR DESCRIPTION
This PR changes the default scope from `SESSION` to `GLOBAL` for the following options (see #430 and #444 for details):

 - `pg_pool_acquire_mode`
 - `pg_pool_max_connections`
 - `pg_pool_wait_timeout_millis`
 - `pg_pool_enable_thread_local_cache`
 - `pg_pool_max_lifetime_millis`
 - `pg_pool_idle_timeout_millis`
 - `pg_pool_enable_reaper_thread`
 - `pg_pool_health_check_query`

Additionally it changes the default size of the connection pool to `max(cpu_count * 1.5, 8)`.

Fixes: duckdb/ducklake#1031