### PR TITLE
Connection pool: change defaults, more metrics

### DIFF
--- a/src/include/storage/postgres_connection_pool.hpp
+++ b/src/include/storage/postgres_connection_pool.hpp
@@ -24,8 +24,6 @@ class PostgresConnectionPool;
 
 using PostgresPoolConnection = dbconnector::pool::PooledConnection<PostgresConnection>;
 
-enum class PostgresPoolAcquireMode { FORCE, WAIT, TRY };
-
 class PostgresConnectionPool : public dbconnector::pool::ConnectionPool<PostgresConnection> {
 public:
 	PostgresConnectionPool(PostgresCatalog &postgres_catalog, ClientContext &context);
@@ -38,13 +36,9 @@ public:
 
 	std::string GetHealthCheckQuery();
 	void SetHealthCheckQuery(const std::string &query);
-	PostgresPoolAcquireMode GetAcquireMode();
-	void SetAcquireMode(PostgresPoolAcquireMode mode);
 
 	static idx_t DefaultPoolSize();
 	static std::string DefaultHealthCheckQuery();
-	static PostgresPoolAcquireMode AcquireModeFromString(const std::string &mode_str);
-	static std::string AcquireModeToString(PostgresPoolAcquireMode mode);
 	static void ValidatePoolAcquireMode(ClientContext &context, SetScope scope, Value &parameter);
 
 protected:
@@ -57,7 +51,6 @@ private:
 
 	std::mutex config_mutex;
 	std::string health_check_query;
-	PostgresPoolAcquireMode acquire_mode = PostgresPoolAcquireMode::FORCE;
 
 	bool PoolEnabled();
 };

--- a/src/storage/postgres_configure_pool.cpp
+++ b/src/storage/postgres_configure_pool.cpp
@@ -15,7 +15,7 @@ enum class ExecState { UNINITIALIZED, EXHAUSTED };
 
 struct ConfigurePoolBindData : public TableFunctionData {
 	std::pair<std::string, bool> catalog_name;
-	std::pair<PostgresPoolAcquireMode, bool> acquire_mode;
+	std::pair<dbconnector::pool::AcquireMode, bool> acquire_mode;
 	std::pair<uint64_t, bool> max_connections;
 	std::pair<uint64_t, bool> wait_timeout_millis;
 	std::pair<bool, bool> enable_thread_local_cache;
@@ -59,16 +59,16 @@ struct ConfigurePoolBindData : public TableFunctionData {
 		return std::make_pair(flag, false);
 	}
 
-	static std::pair<PostgresPoolAcquireMode, bool> LookupAcquireMode(const named_parameter_map_t &map,
-	                                                                  const std::string &key) {
+	static std::pair<dbconnector::pool::AcquireMode, bool> LookupAcquireMode(const named_parameter_map_t &map,
+	                                                                         const std::string &key) {
 		std::pair<std::string, bool> st_pair = LookupString(map, key);
 		if (st_pair.second) {
-			return std::make_pair(PostgresPoolAcquireMode::FORCE, true);
+			return std::make_pair(dbconnector::pool::AcquireMode::FORCE, true);
 		}
 		try {
-			PostgresPoolAcquireMode mode = PostgresConnectionPool::AcquireModeFromString(st_pair.first);
+			dbconnector::pool::AcquireMode mode = dbconnector::pool::AcquireModeHelpers::FromString(st_pair.first);
 			return std::make_pair(mode, false);
-		} catch (InvalidInputException &e) {
+		} catch (const std::exception &e) {
 			throw BinderException(e.what());
 		}
 	}
@@ -113,12 +113,16 @@ static unique_ptr<FunctionData> ConfigurePoolBind(ClientContext &context, TableF
 	AddColumn(return_types, names, "available_connections", LogicalType::UBIGINT);
 	AddColumn(return_types, names, "max_connections", LogicalType::UBIGINT);
 	AddColumn(return_types, names, "wait_timeout_millis", LogicalType::UBIGINT);
+	AddColumn(return_types, names, "cache_hits", LogicalType::UBIGINT);
+	AddColumn(return_types, names, "cache_misses", LogicalType::UBIGINT);
+	AddColumn(return_types, names, "try_failures", LogicalType::UBIGINT);
 	AddColumn(return_types, names, "thread_local_cache_enabled", LogicalType::BOOLEAN);
 	AddColumn(return_types, names, "thread_local_cache_hits", LogicalType::UBIGINT);
 	AddColumn(return_types, names, "thread_local_cache_misses", LogicalType::UBIGINT);
 	AddColumn(return_types, names, "max_lifetime_millis", LogicalType::UBIGINT);
 	AddColumn(return_types, names, "idle_timeout_millis", LogicalType::UBIGINT);
 	AddColumn(return_types, names, "reaper_thread_running", LogicalType::BOOLEAN);
+	AddColumn(return_types, names, "reaper_thread_period_millis", LogicalType::UBIGINT);
 	AddColumn(return_types, names, "health_check_query", LogicalType::VARCHAR);
 
 	return make_uniq<ConfigurePoolBindData>(input.named_parameters);
@@ -202,16 +206,21 @@ static void ConfigurePoolFunction(ClientContext &context, TableFunctionInput &in
 	for (auto &pool : pools) {
 		idx_t col_idx = 0;
 		output.SetValue(col_idx++, row_idx, Value(cat_names.at(row_idx)));
-		output.SetValue(col_idx++, row_idx, Value(PostgresConnectionPool::AcquireModeToString(pool->GetAcquireMode())));
+		output.SetValue(col_idx++, row_idx,
+		                Value(dbconnector::pool::AcquireModeHelpers::ToString(pool->GetAcquireMode())));
 		output.SetValue(col_idx++, row_idx, Value::UBIGINT(pool->GetAvailableConnections()));
 		output.SetValue(col_idx++, row_idx, Value::UBIGINT(pool->GetMaxConnections()));
 		output.SetValue(col_idx++, row_idx, Value::UBIGINT(pool->GetWaitTimeoutMillis()));
+		output.SetValue(col_idx++, row_idx, Value::UBIGINT(pool->GetCacheHits()));
+		output.SetValue(col_idx++, row_idx, Value::UBIGINT(pool->GetCacheMisses()));
+		output.SetValue(col_idx++, row_idx, Value::UBIGINT(pool->GetTryFailures()));
 		output.SetValue(col_idx++, row_idx, Value::BOOLEAN(pool->IsThreadLocalCacheEnabled()));
 		output.SetValue(col_idx++, row_idx, Value::UBIGINT(pool->GetThreadLocalCacheHits()));
 		output.SetValue(col_idx++, row_idx, Value::UBIGINT(pool->GetThreadLocalCacheMisses()));
 		output.SetValue(col_idx++, row_idx, Value::UBIGINT(pool->GetMaxLifetimeMillis()));
 		output.SetValue(col_idx++, row_idx, Value::UBIGINT(pool->GetIdleTimeoutMillis()));
 		output.SetValue(col_idx++, row_idx, Value::BOOLEAN(pool->IsReaperRunning()));
+		output.SetValue(col_idx++, row_idx, Value::UBIGINT(pool->GetReaperPeriodMillis()));
 		output.SetValue(col_idx++, row_idx, Value(pool->GetHealthCheckQuery()));
 		row_idx++;
 	}

--- a/src/storage/postgres_connection_pool.cpp
+++ b/src/storage/postgres_connection_pool.cpp
@@ -19,17 +19,9 @@ static std::string GetHealthCheckQueryFromConfig(ClientContext &context) {
 	return PostgresConnectionPool::DefaultHealthCheckQuery();
 }
 
-static PostgresPoolAcquireMode GetAcquireModeFromConfig(ClientContext &context) {
-	Value mode_val;
-	if (context.TryGetCurrentSetting("pg_pool_acquire_mode", mode_val)) {
-		return PostgresConnectionPool::AcquireModeFromString(mode_val.ToString());
-	}
-	return PostgresPoolAcquireMode::FORCE;
-}
-
 PostgresConnectionPool::PostgresConnectionPool(PostgresCatalog &postgres_catalog, ClientContext &context)
     : dbconnector::pool::ConnectionPool<PostgresConnection>(CreateConfig(context)), postgres_catalog(postgres_catalog),
-      health_check_query(GetHealthCheckQueryFromConfig(context)), acquire_mode(GetAcquireModeFromConfig(context)) {
+      health_check_query(GetHealthCheckQueryFromConfig(context)) {
 }
 
 PostgresPoolConnection PostgresConnectionPool::ForceGetConnection() {
@@ -46,20 +38,7 @@ bool PostgresConnectionPool::TryGetConnection(PostgresPoolConnection &connection
 }
 
 PostgresPoolConnection PostgresConnectionPool::GetConnection() {
-	if (!PoolEnabled()) {
-		return ForceAcquire();
-	}
-	PostgresPoolAcquireMode mode = GetAcquireMode();
-	switch (mode) {
-	case PostgresPoolAcquireMode::FORCE:
-		return ForceAcquire();
-	case PostgresPoolAcquireMode::WAIT:
-		return WaitAcquire();
-	case PostgresPoolAcquireMode::TRY:
-		return TryAcquire();
-	default:
-		throw IOException("Invalid unsupported acquire mode: %d" + static_cast<int>(mode));
-	}
+	return Acquire();
 }
 
 std::unique_ptr<PostgresConnection> PostgresConnectionPool::CreateNewConnection() {
@@ -90,16 +69,6 @@ void PostgresConnectionPool::SetHealthCheckQuery(const std::string &query) {
 	this->health_check_query = std::string(query.data(), query.length());
 }
 
-PostgresPoolAcquireMode PostgresConnectionPool::GetAcquireMode() {
-	std::lock_guard<std::mutex> guard(config_mutex);
-	return acquire_mode;
-}
-
-void PostgresConnectionPool::SetAcquireMode(PostgresPoolAcquireMode mode) {
-	std::lock_guard<std::mutex> guard(config_mutex);
-	this->acquire_mode = mode;
-}
-
 idx_t PostgresConnectionPool::DefaultPoolSize() {
 	idx_t detected = static_cast<idx_t>(std::thread::hardware_concurrency());
 	idx_t detected_adjusted = detected * 3 / 2;
@@ -114,6 +83,12 @@ std::string PostgresConnectionPool::DefaultHealthCheckQuery() {
 static dbconnector::pool::ConnectionPoolConfig CreateConfig(ClientContext &ctx) {
 	dbconnector::pool::ConnectionPoolConfig config;
 
+	{
+		Value mode_val;
+		if (ctx.TryGetCurrentSetting("pg_pool_acquire_mode", mode_val)) {
+			config.acquire_mode = dbconnector::pool::AcquireModeHelpers::FromString(mode_val.ToString());
+		}
+	}
 	{
 		Value val;
 		if (ctx.TryGetCurrentSetting("pg_pool_max_connections", val) && !val.IsNull()) {
@@ -158,40 +133,14 @@ bool PostgresConnectionPool::PoolEnabled() {
 	return GetMaxConnections() > 0;
 }
 
-PostgresPoolAcquireMode PostgresConnectionPool::AcquireModeFromString(const std::string &mode_str) {
-	auto ms = StringUtil::Lower(mode_str);
-	if (ms == "force") {
-		return PostgresPoolAcquireMode::FORCE;
-	} else if (ms == "wait") {
-		return PostgresPoolAcquireMode::WAIT;
-	} else if (ms == "try") {
-		return PostgresPoolAcquireMode::TRY;
-	} else {
-		throw InvalidInputException("Invalid unsupported acquire mode: '%s'", mode_str);
-	}
-}
-
-std::string PostgresConnectionPool::AcquireModeToString(PostgresPoolAcquireMode mode) {
-	switch (mode) {
-	case PostgresPoolAcquireMode::FORCE:
-		return "force";
-	case PostgresPoolAcquireMode::WAIT:
-		return "wait";
-	case PostgresPoolAcquireMode::TRY:
-		return "try";
-	default:
-		throw InvalidInputException("Invalid unsupported acquire mode: %d" + static_cast<int>(mode));
-	}
-}
-
 void PostgresConnectionPool::ValidatePoolAcquireMode(ClientContext &context, SetScope scope, Value &parameter) {
-	PostgresPoolAcquireMode mode = AcquireModeFromString(parameter.ToString());
-	if (mode != PostgresPoolAcquireMode::FORCE) {
+	dbconnector::pool::AcquireMode mode = dbconnector::pool::AcquireModeHelpers::FromString(parameter.ToString());
+	if (mode != dbconnector::pool::AcquireMode::FORCE) {
 		Value pool_size_val;
 		if (context.TryGetCurrentSetting("pg_pool_max_connections", pool_size_val)) {
 			auto pool_size = pool_size_val.GetValue<uint64_t>();
 			if (pool_size == 0) {
-				std::string mode_str = AcquireModeToString(mode);
+				std::string mode_str = dbconnector::pool::AcquireModeHelpers::ToString(mode);
 				throw InvalidInputException(
 				    "pg_pool_pool_acquire_mode='%s' requires pg_pool_max_connections > 0 (pooling enabled)", mode_str);
 			}

--- a/test/sql/storage/attach_connection_pool_configure.test
+++ b/test/sql/storage/attach_connection_pool_configure.test
@@ -21,13 +21,13 @@ ATTACH 'dbname=postgresscanner' AS s1 (TYPE POSTGRES);
 statement ok
 RESET GLOBAL pg_pool_max_connections
 
-query II
-SELECT catalog_name, max_connections 
+query IIIIIIIIIII
+SELECT catalog_name, max_connections, cache_hits, cache_misses, try_failures, thread_local_cache_enabled, max_lifetime_millis, idle_timeout_millis, reaper_thread_running, reaper_thread_period_millis, health_check_query
 FROM postgres_configure_pool()
 ORDER BY catalog_name
 ----
-s	8
-s1	8
+s	8	0	1	0	FALSE	0	60000	1	30000	SELECT 1
+s1	8	0	1	0	FALSE	0	60000	1	30000	SELECT 1
 
 query II
 SELECT catalog_name, acquire_mode

--- a/test/sql/storage/attach_verify_big_table.test_slow
+++ b/test/sql/storage/attach_verify_big_table.test_slow
@@ -6,6 +6,8 @@ require postgres_scanner
 
 require-env POSTGRES_TEST_DATABASE_AVAILABLE
 
+require-env POSTGRES_TEST_SLOW
+
 statement ok
 ATTACH 'dbname=postgresscanner' AS s1 (TYPE POSTGRES)
 


### PR DESCRIPTION
This PR changes the default settings of the connection pool to the following:

 - `acquire_mode`: `force`
 - `max_connections`: `4 <= cpu_count * 1.5 <= 32`
 - `wait_timeout_millis`: `30000`
 - `enable_thread_local_cache`: `FALSE`
 - `max_lifetime_millis`: `0` (not enforced)
 - `idle_timeout_millis`: `60000`
 - `enable_reaper_thread`: `TRUE`
 - `health_check_query`: `SELECT 1`

Note, that `enable_thread_local_cache` is now disabled and `enable_reaper_thread` is not enabled. Supported options remain the same, see #430 and #444 for their description.

It also exposes additional metrics in the output of the `postgres_configure_pool()` function, full list:

 - `catalog_name` (`VARCHAR`): the name (alias) of the attached Postgres database
 - `acquire_mode` (`VARCHAR`): how to acquire connections from the pool: 'force' (always connect, ignore pool limit), 'wait' (block until available), 'try' (fail immediately if unavailable)
 - `available_connections` (`UBIGINT`): the number of idle connection that are currently available in the pool
 - `max_connections` (`UBIGINT`): maximum number of connections that are allowed to be cached in the pool.
 - `wait_timeout_millis` (`UBIGINT`): maximum number of milliseconds to wait when acquiring a connection from a pool where all available connections are already taken; only applicable to the `wait` acquire-mode
 - `cache_hits` (`UBIGINT`): number of times a cached connection was successfully returned from the pool
 - `cache_misses` (`UBIGINT`): number of times a new connection was created by the pool
 - `try_failures` (`UBIGINT`): number of times a connection was requested by the pool in `try` acquire-mode and no connection was available at the time - so no connection was provided by the pool; note that when the parallel scans are performed by the Postgres extension - worker threads always use the `try` acquire mode; when `SET threads = <number_higher_then_pool_size>` is used, then some of the worker threads are unable to obtain a connection - they return without doing any work and without throwing an error
 - `thread_local_cache_enabled` (`BOOLEAN`): whether caching the connections caching in thread-local cache is enabled; thread-local connections are **NOT** cleared by the reaper thread
 - `thread_local_cache_hits` (`UBIGINT`): the number of times connections were successfully acquired from a thread-local cache without going to the main pool
 - `thread_local_cache_misses` (`UBIGINT`): the number of times connections were not available in a thread-local cache and were taken from the main pool instead
 - `max_lifetime_millis` (`UBIGINT`): maximum number of milliseconds a connection can be kept open
 - `idle_timeout_millis` (`UBIGINT`): maximum number of milliseconds a connection can be kept idle in the pool
 - `reaper_thread_running` (`BOOLEAN`): whether the pool reaper thread is running; this thread periodically scans the pool to check the 'max_lifetime_millis' and 'idle_timeout_millis' and closes connections which exceed the specified values
 - `reaper_thread_period_millis` (`UBIGINT`): the period of time when a reaper thread performs the checks
 - `health_check_query` (`VARCHAR`): the query that is used to check that the connection is healthy

Ref: duckdb/ducklake#1031