### PR TITLE
Add OAuth bearer token injection via PQsetAuthDataHook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,8 @@ endif()
 include_directories(
     include
     database-connector/src/include
-    ${OPENSSL_INCLUDE_DIR})
+    ${OPENSSL_INCLUDE_DIR}
+    ${PostgreSQL_INCLUDE_DIRS})
 
 if(WIN32)
   include_directories(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,8 @@ add_library(
   postgres_storage.cpp
   postgres_text_reader.cpp
   postgres_utils.cpp
-  postgres_logging.cpp)
+  postgres_logging.cpp
+  postgres_oauth.cpp)
 set(ALL_OBJECT_FILES
     ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:postgres_ext_library>
     PARENT_SCOPE)

--- a/src/include/postgres_oauth.hpp
+++ b/src/include/postgres_oauth.hpp
@@ -12,15 +12,18 @@
 
 namespace duckdb {
 
+struct OAuthTokenHolder {
+	~OAuthTokenHolder();
+};
+
 //! Initializes the PQsetAuthDataHook for OAuth bearer token injection.
 //! The hook provides tokens from either the PGOAUTHTOKEN environment variable
 //! or the pg_oauth_token DuckDB setting.
 void PostgresInitOAuthHook();
 
-//! Sets the in-memory OAuth token (used by the pg_oauth_token setting)
-void PostgresSetOAuthToken(const string &token);
-
-//! Clears the in-memory OAuth token
-void PostgresClearOAuthToken();
+//! Gets the 'oauth_token' value from the 'pg_oauth_token option',
+//! sets it to a thread-local var to be available to PG auth hook;
+//! should be called at all call sites that are about to open the new connection.
+OAuthTokenHolder SetThreadLocalOAuthTokenFromSessionOption(ClientContext &ctx);
 
 } // namespace duckdb

--- a/src/include/postgres_oauth.hpp
+++ b/src/include/postgres_oauth.hpp
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// postgres_oauth.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "duckdb.hpp"
+
+namespace duckdb {
+
+//! Initializes the PQsetAuthDataHook for OAuth bearer token injection.
+//! The hook provides tokens from either the PGOAUTHTOKEN environment variable
+//! or the pg_oauth_token DuckDB setting.
+void PostgresInitOAuthHook();
+
+//! Sets the in-memory OAuth token (used by the pg_oauth_token setting)
+void PostgresSetOAuthToken(const string &token);
+
+//! Clears the in-memory OAuth token
+void PostgresClearOAuthToken();
+
+} // namespace duckdb

--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -115,14 +115,6 @@ static std::string CreatePoolNote(const std::string &option) {
 	       "\"FROM postgres_configure_pool(catalog_name='my_attached_postgres_db', " + option + ")\"";
 }
 
-static void SetOAuthToken(ClientContext &context, SetScope scope, Value &parameter) {
-	if (parameter.IsNull() || StringValue::Get(parameter).empty()) {
-		PostgresClearOAuthToken();
-	} else {
-		PostgresSetOAuthToken(StringValue::Get(parameter));
-	}
-}
-
 static void LoadInternal(ExtensionLoader &loader) {
 	// Register the OAuth bearer token hook before any connections are made
 	PostgresInitOAuthHook();
@@ -207,7 +199,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	config.AddExtensionOption("pg_oauth_token",
 	                          "OAuth bearer token for PostgreSQL OAUTHBEARER authentication. "
 	                          "Takes priority over the PGOAUTHTOKEN environment variable",
-	                          LogicalType::VARCHAR, Value(), SetOAuthToken);
+	                          LogicalType::VARCHAR, Value(), nullptr, SetScope::SESSION);
 	config.AddExtensionOption("pg_use_text_protocol",
 	                          "Whether or not to use TEXT protocol to read data. This is slower, but provides better "
 	                          "compatibility with non-Postgres systems",

--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -23,6 +23,7 @@
 #include "duckdb/common/error_data.hpp"
 #include "postgres_logging.hpp"
 #include "postgres_hstore.hpp"
+#include "postgres_oauth.hpp"
 
 using namespace duckdb;
 
@@ -114,7 +115,18 @@ static std::string CreatePoolNote(const std::string &option) {
 	       "\"FROM postgres_configure_pool(catalog_name='my_attached_postgres_db', " + option + ")\"";
 }
 
+static void SetOAuthToken(ClientContext &context, SetScope scope, Value &parameter) {
+	if (parameter.IsNull() || StringValue::Get(parameter).empty()) {
+		PostgresClearOAuthToken();
+	} else {
+		PostgresSetOAuthToken(StringValue::Get(parameter));
+	}
+}
+
 static void LoadInternal(ExtensionLoader &loader) {
+	// Register the OAuth bearer token hook before any connections are made
+	PostgresInitOAuthHook();
+
 	PostgresScanFunction postgres_fun;
 	loader.RegisterFunction(postgres_fun);
 
@@ -192,6 +204,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          LogicalType::VARCHAR, Value(), SetPostgresNullByteReplacement);
 	config.AddExtensionOption("pg_debug_show_queries", "DEBUG SETTING: print all queries sent to Postgres to stdout",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(false), SetPostgresDebugQueryPrint);
+	config.AddExtensionOption("pg_oauth_token",
+	                          "OAuth bearer token for PostgreSQL OAUTHBEARER authentication. "
+	                          "Takes priority over the PGOAUTHTOKEN environment variable",
+	                          LogicalType::VARCHAR, Value(), SetOAuthToken);
 	config.AddExtensionOption("pg_use_text_protocol",
 	                          "Whether or not to use TEXT protocol to read data. This is slower, but provides better "
 	                          "compatibility with non-Postgres systems",

--- a/src/postgres_oauth.cpp
+++ b/src/postgres_oauth.cpp
@@ -18,17 +18,22 @@ extern "C" {
 
 namespace duckdb {
 
-//! Global mutex protecting the token string
-static std::mutex oauth_token_mutex;
-//! The in-memory token set via the DuckDB setting
-static std::string oauth_token_value;
-
 //! Previous hook in the chain (if any)
 static PQauthDataHook_type prev_hook = nullptr;
 
 struct OAuthTokenState {
 	char *token_copy;
 };
+
+//! Managed by SetThreadLocalOAuthTokenFromSessionOption
+static thread_local std::string oauth_token;
+
+OAuthTokenHolder::~OAuthTokenHolder() {
+	if (!oauth_token.empty()) {
+		SecureZero(&oauth_token[0], oauth_token.length());
+		oauth_token.clear();
+	}
+}
 
 static void OAuthTokenCleanup(PGconn *conn, PGoauthBearerRequest *request) {
 	auto *ts = static_cast<OAuthTokenState *>(request->user);
@@ -47,12 +52,8 @@ static int OAuthBearerTokenHook(PGauthData type, PGconn *conn, void *data) {
 	if (type == PQAUTHDATA_OAUTH_BEARER_TOKEN) {
 		const char *token = nullptr;
 
-		// Priority 1: DuckDB setting (more secure, in-process memory only)
-		std::string token_str;
-		{
-			std::lock_guard<std::mutex> lock(oauth_token_mutex);
-			token_str = oauth_token_value;
-		}
+		// Priority 1: thread-local token set by the calling thread from the 'pg_oauth_token' option
+		std::string token_str = oauth_token;
 
 		// Priority 2: Environment variable PGOAUTHTOKEN
 		if (token_str.empty()) {
@@ -96,20 +97,13 @@ void PostgresInitOAuthHook() {
 	PQsetAuthDataHook(OAuthBearerTokenHook);
 }
 
-void PostgresSetOAuthToken(const string &token) {
-	std::lock_guard<std::mutex> lock(oauth_token_mutex);
-	if (!oauth_token_value.empty()) {
-		SecureZero(&oauth_token_value[0], oauth_token_value.size());
+OAuthTokenHolder SetThreadLocalOAuthTokenFromSessionOption(ClientContext &ctx) {
+	Value val;
+	if (ctx.TryGetCurrentSetting("pg_oauth_token", val) && !val.IsNull()) {
+		std::string token = StringValue::Get(val);
+		oauth_token = std::string(token.data(), token.length());
 	}
-	oauth_token_value = token;
-}
-
-void PostgresClearOAuthToken() {
-	std::lock_guard<std::mutex> lock(oauth_token_mutex);
-	if (!oauth_token_value.empty()) {
-		SecureZero(&oauth_token_value[0], oauth_token_value.size());
-	}
-	oauth_token_value.clear();
+	return OAuthTokenHolder();
 }
 
 } // namespace duckdb

--- a/src/postgres_oauth.cpp
+++ b/src/postgres_oauth.cpp
@@ -1,0 +1,115 @@
+#include "postgres_oauth.hpp"
+
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <string>
+
+#ifdef _WIN32
+#include <windows.h>
+#define SecureZero(ptr, len) SecureZeroMemory(ptr, len)
+#else
+#define SecureZero(ptr, len) explicit_bzero(ptr, len)
+#endif
+
+extern "C" {
+#include "libpq-fe.h"
+}
+
+namespace duckdb {
+
+//! Global mutex protecting the token string
+static std::mutex oauth_token_mutex;
+//! The in-memory token set via the DuckDB setting
+static std::string oauth_token_value;
+
+//! Previous hook in the chain (if any)
+static PQauthDataHook_type prev_hook = nullptr;
+
+struct OAuthTokenState {
+	char *token_copy;
+};
+
+static void OAuthTokenCleanup(PGconn *conn, PGoauthBearerRequest *request) {
+	auto *ts = static_cast<OAuthTokenState *>(request->user);
+	if (ts) {
+		if (ts->token_copy) {
+			SecureZero(ts->token_copy, strlen(ts->token_copy));
+			free(ts->token_copy);
+		}
+		free(ts);
+		request->user = nullptr;
+	}
+	request->token = nullptr;
+}
+
+static int OAuthBearerTokenHook(PGauthData type, PGconn *conn, void *data) {
+	if (type == PQAUTHDATA_OAUTH_BEARER_TOKEN) {
+		const char *token = nullptr;
+
+		// Priority 1: DuckDB setting (more secure, in-process memory only)
+		std::string token_str;
+		{
+			std::lock_guard<std::mutex> lock(oauth_token_mutex);
+			token_str = oauth_token_value;
+		}
+
+		// Priority 2: Environment variable PGOAUTHTOKEN
+		if (token_str.empty()) {
+			const char *env_token = std::getenv("PGOAUTHTOKEN");
+			if (env_token && env_token[0] != '\0') {
+				token_str = env_token;
+			}
+		}
+
+		if (!token_str.empty()) {
+			auto *request = static_cast<PGoauthBearerRequest *>(data);
+
+			auto *ts = static_cast<OAuthTokenState *>(malloc(sizeof(OAuthTokenState)));
+			if (!ts) {
+				return -1;
+			}
+
+			ts->token_copy = strdup(token_str.c_str());
+			if (!ts->token_copy) {
+				free(ts);
+				return -1;
+			}
+
+			request->token = ts->token_copy;
+			request->cleanup = OAuthTokenCleanup;
+			request->user = ts;
+			request->async = nullptr;
+			return 1;
+		}
+	}
+
+	// Fall through to previous hook
+	if (prev_hook) {
+		return prev_hook(type, conn, data);
+	}
+	return 0;
+}
+
+void PostgresInitOAuthHook() {
+	prev_hook = PQgetAuthDataHook();
+	PQsetAuthDataHook(OAuthBearerTokenHook);
+}
+
+void PostgresSetOAuthToken(const string &token) {
+	std::lock_guard<std::mutex> lock(oauth_token_mutex);
+	if (!oauth_token_value.empty()) {
+		SecureZero(&oauth_token_value[0], oauth_token_value.size());
+	}
+	oauth_token_value = token;
+}
+
+void PostgresClearOAuthToken() {
+	std::lock_guard<std::mutex> lock(oauth_token_mutex);
+	if (!oauth_token_value.empty()) {
+		SecureZero(&oauth_token_value[0], oauth_token_value.size());
+	}
+	oauth_token_value.clear();
+}
+
+} // namespace duckdb

--- a/src/postgres_scanner.cpp
+++ b/src/postgres_scanner.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "postgres_oauth.hpp"
 #include "postgres_filter_pushdown.hpp"
 #include "postgres_scanner.hpp"
 #include "postgres_result.hpp"
@@ -411,7 +412,10 @@ bool PostgresGlobalState::TryOpenNewConnection(ClientContext &context, PostgresL
 			} else {
 				// we cannot use the main thread but we haven't initiated ANY scan yet
 				// we HAVE to open a new connection
-				lstate.pool_connection = pg_catalog->GetConnectionPool().ForceGetConnection();
+				{
+					auto oauth_token_holder = SetThreadLocalOAuthTokenFromSessionOption(context);
+					lstate.pool_connection = pg_catalog->GetConnectionPool().ForceGetConnection();
+				}
 				lstate.connection = PostgresConnection(lstate.pool_connection.GetConnection().GetConnection());
 			}
 			used_main_thread = true;
@@ -420,8 +424,11 @@ bool PostgresGlobalState::TryOpenNewConnection(ClientContext &context, PostgresL
 	}
 
 	if (pg_catalog) {
-		if (!pg_catalog->GetConnectionPool().TryGetConnection(lstate.pool_connection)) {
-			return false;
+		{
+			auto oauth_token_holder = SetThreadLocalOAuthTokenFromSessionOption(context);
+			if (!pg_catalog->GetConnectionPool().TryGetConnection(lstate.pool_connection)) {
+				return false;
+			}
 		}
 		lstate.connection = PostgresConnection(lstate.pool_connection.GetConnection().GetConnection());
 		PostgresScanConnect(context, lstate.connection, snapshot, pg_catalog->access_mode, pg_catalog->isolation_level);

--- a/src/storage/postgres_catalog.cpp
+++ b/src/storage/postgres_catalog.cpp
@@ -1,6 +1,7 @@
 #include "storage/postgres_catalog.hpp"
 #include "storage/postgres_schema_entry.hpp"
 #include "storage/postgres_transaction.hpp"
+#include "postgres_oauth.hpp"
 #include "postgres_connection.hpp"
 #include "postgres_secrets.hpp"
 #include "storage/postgres_secret_storage.hpp"
@@ -44,7 +45,11 @@ PostgresCatalog::PostgresCatalog(ClientContext &ctx, AttachedDatabase &db_p, str
 		default_schema = "public";
 	}
 
-	auto connection = connection_pool->GetConnection();
+	PostgresPoolConnection connection;
+	{
+		auto oauth_token_holder = SetThreadLocalOAuthTokenFromSessionOption(ctx);
+		connection = connection_pool->GetConnection();
+	}
 	this->version = connection.GetConnection().GetPostgresVersion(ctx);
 }
 

--- a/src/storage/postgres_transaction.cpp
+++ b/src/storage/postgres_transaction.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/parser/parsed_data/create_view_info.hpp"
 #include "duckdb/catalog/catalog_entry/index_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
+#include "postgres_oauth.hpp"
 #include "postgres_result.hpp"
 
 namespace duckdb {
@@ -11,6 +12,7 @@ PostgresTransaction::PostgresTransaction(PostgresCatalog &postgres_catalog, Tran
                                          ClientContext &context)
     : Transaction(manager, context), access_mode(postgres_catalog.access_mode),
       isolation_level(postgres_catalog.isolation_level) {
+	auto oauth_token_holder = SetThreadLocalOAuthTokenFromSessionOption(context);
 	connection = postgres_catalog.GetConnectionPool().GetConnection();
 }
 

--- a/test/sql/storage/attach_oauth_token.test
+++ b/test/sql/storage/attach_oauth_token.test
@@ -1,0 +1,45 @@
+# name: test/sql/storage/attach_oauth_token.test
+# description: Test OAuth bearer token injection via PQsetAuthDataHook
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+require-env PGOAUTHTOKEN
+
+require-env PG_OAUTH_DSN
+
+# Explicitly load the extension so settings are registered
+statement ok
+LOAD postgres_scanner;
+
+# Test 1: Connect using the pg_oauth_token DuckDB setting
+statement ok
+SET pg_oauth_token = '${PGOAUTHTOKEN}';
+
+statement ok
+ATTACH '${PG_OAUTH_DSN}' AS pg_oauth (TYPE POSTGRES);
+
+query I
+SELECT current_user FROM postgres_query('pg_oauth', 'SELECT current_user');
+----
+admin
+
+statement ok
+DETACH pg_oauth;
+
+# Test 2: Clear the setting and verify env var fallback (PGOAUTHTOKEN) works
+statement ok
+SET pg_oauth_token = '';
+
+statement ok
+ATTACH '${PG_OAUTH_DSN}' AS pg_oauth_env (TYPE POSTGRES);
+
+query I
+SELECT current_user FROM postgres_query('pg_oauth_env', 'SELECT current_user');
+----
+admin
+
+statement ok
+DETACH pg_oauth_env;


### PR DESCRIPTION
This is a continuation of the PR #447, it makes the in-memory OAuth token session scoped, so multiple tokens can be used from the same DuckDB instance.