### PR TITLE
Support AWS RDS IAM authentication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ add_definitions(
 
 find_package(OpenSSL REQUIRED)
 find_package(PostgreSQL REQUIRED)
+find_package(AWSSDK REQUIRED COMPONENTS rds)
 
 if(NOT MSVC)
     add_compile_options(
@@ -52,7 +53,9 @@ endif()
 target_link_libraries(${LOADABLE_EXTENSION_NAME}
     OpenSSL::SSL
     OpenSSL::Crypto
-    PostgreSQL::PostgreSQL)
+    PostgreSQL::PostgreSQL
+    ${AWSSDK_LINK_LIBRARIES}
+    ${CURL_LIBRARIES})
 set_property(TARGET ${EXTENSION_NAME} PROPERTY C_STANDARD 99)
 set_property(TARGET ${LOADABLE_EXTENSION_NAME} PROPERTY C_STANDARD 99)
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,51 @@ D SELECT * FROM postgres_db.uuids;
 
 For more information on how to use the connector, refer to the [Postgres documentation on the website](https://duckdb.org/docs/extensions/postgres).
 
+### AWS RDS IAM Authentication
+
+The extension supports AWS RDS IAM-based authentication, which allows you to connect to RDS/Aurora PostgreSQL instances using IAM database authentication instead of static passwords. This feature automatically generates temporary authentication tokens using the AWS SDK.
+
+#### Requirements
+
+- RDS instance with IAM database authentication enabled
+- IAM user/role with `rds-db:connect` permission for the RDS instance
+- AWS credentials configured (via `AWS_PROFILE`, `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or IAM role)
+
+#### Usage
+
+To use RDS IAM authentication, create a Postgres secret with the `AWS_RDS_IAM_AUTH_ENABLED` parameter set to `TRUE`:
+
+```sql
+CREATE SECRET rds_secret (
+    TYPE POSTGRES,
+    HOST 'my-db-instance.xxxxxx.us-west-2.rds.amazonaws.com',
+    PORT '5432',
+    USER 'my_iam_user',
+    DATABASE 'postgres',
+    SSLMODE 'require',
+    AWS_RDS_IAM_AUTH_ENABLED TRUE,
+    AWS_REGION 'us-west-2'
+);
+
+ATTACH '' AS rds_db (TYPE POSTGRES, SECRET rds_secret);
+```
+
+#### Secret Parameters for RDS IAM Authentication
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `HOST` | VARCHAR | Yes | RDS/Aurora instance hostname |
+| `PORT` | VARCHAR | Yes | RDS/Aurora instance port (typically 5432) |
+| `USER` | VARCHAR | Yes | IAM database username |
+| `AWS_RDS_IAM_AUTH_ENABLED` | BOOLEAN | Yes | Enable RDS IAM authentication |
+| `AWS_RDS_IAM_TOKEN_EXPIRATION_SECONDS` | BIGINT | No | Token expiration time in seconds, default: 900 (15 min) |
+| `AWS_REGION` | VARCHAR | Yes | AWS region |
+
+#### Important Notes
+
+- **Token Expiration**: RDS auth tokens expire after 15 minutes max. The extension caches tokens for `AWS_RDS_IAM_TOKEN_EXPIRATION_SECONDS - 60` seconds, so new pool connections reuse the cached token rather than obtaining new IAM token each time.
+- **AWS Credentials**: The extension uses the [default credentials provider chain](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/credproviders.html#credproviders-default-credentials-provider-chain), the credential providers are currently NOT configurable.
+
 ## Building & Loading the Extension
 
 The DuckDB submodule must be initialized prior to building.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(storage)
 add_library(
   postgres_ext_library OBJECT
   postgres_attach.cpp
+  postgres_aws.cpp
   postgres_binary_copy.cpp
   postgres_binary_file_reader.cpp
   postgres_binary_parser.cpp

--- a/src/include/postgres_aws.hpp
+++ b/src/include/postgres_aws.hpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//                         DuckDB
+//
+// postgres_aws.hpp
+//
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "duckdb.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
+
+namespace duckdb {
+
+struct PostgresAwsRdsTokenConfig {
+	bool enabled = false;
+	std::string hostname;
+	std::string port;
+	std::string username;
+	std::string region;
+	std::uint64_t expiration_seconds = 900; // 15 min;
+	std::string base_connection_string;
+};
+
+struct PostgresAws {
+	static std::string GenerateRdsAuthToken(const PostgresAwsRdsTokenConfig &token_config);
+
+	static PostgresAwsRdsTokenConfig ExtractTokenConfigFromSecret(optional_ptr<SecretEntry> secret_entry);
+};
+
+} // namespace duckdb

--- a/src/include/postgres_utils.hpp
+++ b/src/include/postgres_utils.hpp
@@ -11,6 +11,7 @@
 #include "duckdb.hpp"
 #include <libpq-fe.h>
 #include "postgres_version.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
 
 namespace duckdb {
 class PostgresSchemaEntry;
@@ -74,6 +75,9 @@ public:
 	static string QuotePostgresIdentifier(const string &text);
 
 	static PostgresVersion ExtractPostgresVersion(const string &version);
+
+	static string EscapeConnectionString(const string &input);
+	static string ExtractConnectionOption(const KeyValueSecret &kv_secret, const string &name);
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_catalog.hpp
+++ b/src/include/storage/postgres_catalog.hpp
@@ -9,9 +9,11 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/enums/access_mode.hpp"
+#include "postgres_aws.hpp"
 #include "postgres_connection.hpp"
 #include "storage/postgres_schema_set.hpp"
 #include "storage/postgres_connection_pool.hpp"
@@ -23,12 +25,11 @@ class PostgresSchemaEntry;
 
 class PostgresCatalog : public Catalog {
 public:
-	explicit PostgresCatalog(AttachedDatabase &db_p, string connection_string, string attach_path,
-	                         AccessMode access_mode, string schema_to_load, PostgresIsolationLevel isolation_level,
-	                         SecretStorageTable secret_storage_table_p, ClientContext &context);
+	explicit PostgresCatalog(ClientContext &ctx, AttachedDatabase &db_p, string attach_path, AccessMode access_mode,
+	                         string schema_to_load, PostgresIsolationLevel isolation_level, const string &secret_name,
+	                         SecretStorageTable secret_storage_table_p);
 	~PostgresCatalog();
 
-	string connection_string;
 	string attach_path;
 	AccessMode access_mode;
 	PostgresIsolationLevel isolation_level;
@@ -42,7 +43,7 @@ public:
 		return default_schema.empty() ? "public" : default_schema;
 	}
 
-	static string GetConnectionString(ClientContext &context, const string &attach_path, string secret_name);
+	string GetConnectionString();
 
 	optional_ptr<CatalogEntry> CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) override;
 
@@ -109,12 +110,21 @@ private:
 
 	void RegisterSecretStorage();
 
+	static unique_ptr<SecretEntry> GetSecretEntry(ClientContext &ctx, const std::string &secret_name);
+	static string CreateConnectionString(optional_ptr<SecretEntry> secret_entry, const string &attach_path);
+
 private:
 	PostgresVersion version;
 	PostgresSchemaSet schemas;
 	shared_ptr<PostgresConnectionPool> connection_pool;
 	string default_schema;
 	SecretStorageTable secret_storage_table;
+
+	PostgresAwsRdsTokenConfig rds_token_config;
+	std::mutex rds_token_mutex;
+	std::string rds_token;
+	std::chrono::steady_clock::time_point rds_token_last_refreshed;
+	std::string connection_string;
 };
 
 } // namespace duckdb

--- a/src/postgres_aws.cpp
+++ b/src/postgres_aws.cpp
@@ -1,0 +1,104 @@
+#include "postgres_aws.hpp"
+
+#include <mutex>
+#include <stdexcept>
+
+#include <aws/core/Aws.h>
+#include <aws/rds/RDSClient.h>
+
+#include "postgres_secrets.hpp"
+#include "postgres_utils.hpp"
+
+namespace duckdb {
+
+static std::mutex sdk_init_mutex;
+static bool sdk_initialized = false;
+static Aws::SDKOptions sdk_options;
+
+static void EnsureAwsSdkInitialized() {
+	std::lock_guard<std::mutex> lock(sdk_init_mutex);
+	if (!sdk_initialized) {
+		Aws::InitAPI(sdk_options);
+		sdk_initialized = true;
+	}
+}
+
+std::string PostgresAws::GenerateRdsAuthToken(const PostgresAwsRdsTokenConfig &token_config) {
+	EnsureAwsSdkInitialized();
+
+	Aws::Client::ClientConfiguration config;
+	config.region = token_config.region;
+	Aws::RDS::RDSClient rds_client(config);
+
+	// https://github.com/aws/aws-sdk-cpp/issues/861#issuecomment-386643571
+	// Aws::String token = rdsClient.GenerateConnectAuthToken(hostname.c_str(), aws_region.c_str(),
+	// static_cast<unsigned>(port_int), username.c_str());
+
+	std::string host_and_port = token_config.hostname + ":" + token_config.port;
+	std::string host_and_port_with_prefix = "http://" + host_and_port;
+	std::string host_and_port_with_suffix = host_and_port + "/";
+	Aws::Http::URI uri(host_and_port_with_prefix.c_str());
+	uri.AddQueryStringParameter("Action", "connect");
+	uri.AddQueryStringParameter("DBUser", token_config.username.c_str());
+	auto token = rds_client.GeneratePresignedUrl(uri, Aws::Http::HttpMethod::HTTP_GET, token_config.region.c_str(),
+	                                             "rds-db", static_cast<long long>(token_config.expiration_seconds));
+	Aws::Utils::StringUtils::Replace(token, host_and_port_with_prefix.c_str(), host_and_port_with_suffix.c_str());
+
+	std::string token_str = token.c_str();
+	return token_str;
+}
+
+static std::string ExtractString(const KeyValueSecret &kv, const std::string name) {
+	Value val = kv.TryGetValue(name);
+	if (val.IsNull()) {
+		return std::string();
+	}
+	std::string str = StringValue::Get(val);
+	StringUtil::Trim(str);
+	return str;
+}
+
+PostgresAwsRdsTokenConfig PostgresAws::ExtractTokenConfigFromSecret(optional_ptr<SecretEntry> secret_entry) {
+	PostgresAwsRdsTokenConfig config;
+	if (!secret_entry) {
+		return config;
+	}
+	const auto &kv = dynamic_cast<const KeyValueSecret &>(*secret_entry->secret);
+	Value enabled_val = kv.TryGetValue("aws_rds_iam_auth_enabled");
+	if (enabled_val.IsNull() || !BooleanValue::Get(enabled_val)) {
+		return config;
+	}
+
+	config.enabled = true;
+	config.hostname = ExtractString(kv, "host");
+	config.port = ExtractString(kv, "port");
+	config.username = ExtractString(kv, "user");
+	config.region = ExtractString(kv, "aws_region");
+	if (config.hostname.empty() || config.port.empty() || config.username.empty()) {
+		throw BinderException("Invalid AWS RDS IAM auth secret configuration: 'HOST', 'PORT', 'USER' and 'AWS_REGION' "
+		                      "parameters must be specified");
+	}
+
+	std::string password = ExtractString(kv, "password");
+	if (!password.empty()) {
+		throw BinderException("Invalid AWS RDS IAM auth secret configuration: 'PASSWORD' parameters must not be "
+		                      "specified - IAM token will be used instead of the password");
+	}
+
+	Value expiration_seconds_val = kv.TryGetValue("aws_rds_iam_token_expiration_seconds");
+	if (!expiration_seconds_val.IsNull()) {
+		config.expiration_seconds = UBigIntValue::Get(expiration_seconds_val);
+	}
+
+	// Build the base connection string (without password)
+	for (const string opt_name : PostgresSecrets::ConnectionOptionNames()) {
+		if (opt_name == "password" || opt_name == "passfile") {
+			continue;
+		}
+		config.base_connection_string += PostgresUtils::ExtractConnectionOption(kv, opt_name);
+	}
+
+	return config;
+}
+
+} // namespace duckdb

--- a/src/postgres_secrets.cpp
+++ b/src/postgres_secrets.cpp
@@ -68,7 +68,10 @@ static const std::unordered_map<std::string, std::string> connection_option_alia
 };
 
 static const std::vector<std::string> other_option_names = {
-  "uri"
+  "uri",
+  "aws_rds_iam_auth_enabled",
+  "aws_rds_iam_token_expiration_seconds",
+  "aws_region"
 };
 // clang-format on
 
@@ -97,7 +100,6 @@ unique_ptr<BaseSecret> PostgresSecrets::CreateFunction(ClientContext &context, C
 		}
 		result->secret_map[name] = named_param.second.ToString();
 	}
-	//! Set redact keys
 	result->redact_keys = {"password", "sslpassword", "oauth_client_secret", "uri"};
 	return std::move(result);
 }
@@ -109,9 +111,11 @@ void PostgresSecrets::SetSecretParameters(CreateSecretFunction &function) {
 	for (auto &en : connection_option_aliases) {
 		function.named_parameters[en.first] = LogicalType::VARCHAR;
 	}
-	for (const std::string &name : other_option_names) {
-		function.named_parameters[name] = LogicalType::VARCHAR;
-	}
+	// other options
+	function.named_parameters["uri"] = LogicalType::VARCHAR;
+	function.named_parameters["aws_rds_iam_auth_enabled"] = LogicalType::BOOLEAN;
+	function.named_parameters["aws_rds_iam_token_expiration_seconds"] = LogicalType::UBIGINT;
+	function.named_parameters["aws_region"] = LogicalType::VARCHAR;
 }
 
 } // namespace duckdb

--- a/src/postgres_storage.cpp
+++ b/src/postgres_storage.cpp
@@ -51,10 +51,9 @@ static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> sto
 	}
 	SecretStorageTable secret_storage_table(std::move(secret_storage_table_name),
 	                                        secret_storage_table_specified_explicitly);
-	auto connection_string = PostgresCatalog::GetConnectionString(context, attach_path, secret_name);
-	return make_uniq<PostgresCatalog>(db, std::move(connection_string), std::move(attach_path),
-	                                  attach_options.access_mode, std::move(schema_to_load), isolation_level,
-	                                  std::move(secret_storage_table), context);
+	return make_uniq<PostgresCatalog>(context, db, std::move(attach_path), attach_options.access_mode,
+	                                  std::move(schema_to_load), isolation_level, secret_name,
+	                                  std::move(secret_storage_table));
 }
 
 static unique_ptr<TransactionManager> PostgresCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,

--- a/src/postgres_utils.cpp
+++ b/src/postgres_utils.cpp
@@ -537,4 +537,33 @@ string PostgresUtils::QuotePostgresIdentifier(const string &text) {
 	return KeywordHelper::WriteOptionallyQuoted(text, '"', false);
 }
 
+string PostgresUtils::EscapeConnectionString(const string &input) {
+	string result = "'";
+	for (auto c : input) {
+		if (c == '\\') {
+			result += "\\\\";
+		} else if (c == '\'') {
+			result += "\\'";
+		} else {
+			result += c;
+		}
+	}
+	result += "'";
+	return result;
+}
+
+string PostgresUtils::ExtractConnectionOption(const KeyValueSecret &kv_secret, const string &name) {
+	Value input_val = kv_secret.TryGetValue(name);
+	if (input_val.IsNull()) {
+		// not provided
+		return string();
+	}
+	string result;
+	result += name;
+	result += "=";
+	result += EscapeConnectionString(input_val.ToString());
+	result += " ";
+	return result;
+}
+
 } // namespace duckdb

--- a/src/storage/postgres_catalog.cpp
+++ b/src/storage/postgres_catalog.cpp
@@ -4,6 +4,7 @@
 #include "postgres_connection.hpp"
 #include "postgres_secrets.hpp"
 #include "storage/postgres_secret_storage.hpp"
+#include "postgres_utils.hpp"
 #include "duckdb/storage/database_size.hpp"
 #include "duckdb/parser/parsed_data/drop_info.hpp"
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
@@ -11,50 +12,6 @@
 #include "duckdb/main/secret/secret_manager.hpp"
 
 namespace duckdb {
-
-PostgresCatalog::PostgresCatalog(AttachedDatabase &db_p, string connection_string_p, string attach_path_p,
-                                 AccessMode access_mode, string schema_to_load, PostgresIsolationLevel isolation_level,
-                                 SecretStorageTable secret_storage_table_p, ClientContext &context)
-    : Catalog(db_p), connection_string(std::move(connection_string_p)), attach_path(std::move(attach_path_p)),
-      access_mode(access_mode), isolation_level(isolation_level), schemas(*this, schema_to_load),
-      secret_storage_table(std::move(secret_storage_table_p)),
-      connection_pool(make_shared_ptr<PostgresConnectionPool>(*this, context)), default_schema(schema_to_load) {
-	if (default_schema.empty()) {
-		default_schema = "public";
-	}
-
-	auto connection = connection_pool->GetConnection();
-	this->version = connection.GetConnection().GetPostgresVersion(context);
-}
-
-string EscapeConnectionString(const string &input) {
-	string result = "'";
-	for (auto c : input) {
-		if (c == '\\') {
-			result += "\\\\";
-		} else if (c == '\'') {
-			result += "\\'";
-		} else {
-			result += c;
-		}
-	}
-	result += "'";
-	return result;
-}
-
-string AddConnectionOption(const KeyValueSecret &kv_secret, const string &name) {
-	Value input_val = kv_secret.TryGetValue(name);
-	if (input_val.IsNull()) {
-		// not provided
-		return string();
-	}
-	string result;
-	result += name;
-	result += "=";
-	result += EscapeConnectionString(input_val.ToString());
-	result += " ";
-	return result;
-}
 
 unique_ptr<SecretEntry> GetSecret(ClientContext &context, const string &secret_name) {
 	auto &secret_manager = SecretManager::Get(context);
@@ -71,16 +28,44 @@ unique_ptr<SecretEntry> GetSecret(ClientContext &context, const string &secret_n
 	return nullptr;
 }
 
-string PostgresCatalog::GetConnectionString(ClientContext &context, const string &attach_path, string secret_name) {
-	// if no secret is specified we default to the unnamed postgres secret, if it exists
-	bool explicit_secret = !secret_name.empty();
-	if (!explicit_secret) {
-		// look up settings from the default unnamed postgres secret if none is provided
-		secret_name = "__default_postgres";
+PostgresCatalog::PostgresCatalog(ClientContext &ctx, AttachedDatabase &db_p, string attach_path_p,
+                                 AccessMode access_mode, string schema_to_load, PostgresIsolationLevel isolation_level,
+                                 const string &secret_name, SecretStorageTable secret_storage_table_p)
+    : Catalog(db_p), attach_path(std::move(attach_path_p)), access_mode(access_mode), isolation_level(isolation_level),
+      secret_storage_table(std::move(secret_storage_table_p)), schemas(*this, schema_to_load),
+      connection_pool(make_shared_ptr<PostgresConnectionPool>(*this, ctx)), default_schema(schema_to_load) {
+	auto secret_entry = GetSecretEntry(ctx, secret_name);
+	this->rds_token_config = PostgresAws::ExtractTokenConfigFromSecret(secret_entry);
+	if (!rds_token_config.enabled) {
+		this->connection_string = CreateConnectionString(secret_entry, attach_path);
 	}
 
+	if (default_schema.empty()) {
+		default_schema = "public";
+	}
+
+	auto connection = connection_pool->GetConnection();
+	this->version = connection.GetConnection().GetPostgresVersion(ctx);
+}
+
+unique_ptr<SecretEntry> PostgresCatalog::GetSecretEntry(ClientContext &ctx, const std::string &secret_name) {
+	std::string name = secret_name;
+	// if no secret is specified we default to the unnamed postgres secret, if it exists
+	bool explicit_secret = !name.empty();
+	if (!explicit_secret) {
+		// look up settings from the default unnamed postgres secret if none is provided
+		name = "__default_postgres";
+	}
+	auto secret_entry = GetSecret(ctx, name);
+	if (!secret_entry && explicit_secret) {
+		// secret not found and one was explicitly provided - throw an error
+		throw BinderException("Secret with name \"%s\" not found", secret_name);
+	}
+	return secret_entry;
+}
+
+string PostgresCatalog::CreateConnectionString(optional_ptr<SecretEntry> secret_entry, const string &attach_path) {
 	string connection_string = attach_path;
-	auto secret_entry = GetSecret(context, secret_name);
 	if (secret_entry) {
 		// secret found - read data
 		const auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*secret_entry->secret);
@@ -105,14 +90,38 @@ string PostgresCatalog::GetConnectionString(ClientContext &context, const string
 
 		string new_connection_info;
 		for (const string opt_name : PostgresSecrets::ConnectionOptionNames()) {
-			new_connection_info += AddConnectionOption(kv_secret, opt_name);
+			new_connection_info += PostgresUtils::ExtractConnectionOption(kv_secret, opt_name);
 		}
 		connection_string = new_connection_info + connection_string;
-	} else if (explicit_secret) {
-		// secret not found and one was explicitly provided - throw an error
-		throw BinderException("Secret with name \"%s\" not found", secret_name);
 	}
 	return connection_string;
+}
+
+string PostgresCatalog::GetConnectionString() {
+	if (!rds_token_config.enabled) {
+		return connection_string;
+	}
+
+	// AWS RDS IAM token hadling below
+	std::lock_guard<std::mutex> rds_token_lock(rds_token_mutex);
+
+	auto now = std::chrono::steady_clock::now();
+	bool expired = false;
+	if (rds_token.empty()) {
+		expired = true;
+	} else {
+		int64_t age_seconds = std::chrono::duration_cast<std::chrono::seconds>(now - rds_token_last_refreshed).count();
+		int64_t max_age = static_cast<int64_t>(rds_token_config.expiration_seconds) - 60;
+		expired = age_seconds > max_age;
+	}
+
+	if (expired) {
+		this->rds_token = PostgresAws::GenerateRdsAuthToken(rds_token_config);
+		this->rds_token_last_refreshed = now;
+		this->connection_string = rds_token_config.base_connection_string +
+		                          "password=" + PostgresUtils::EscapeConnectionString(rds_token) + " " + attach_path;
+	}
+	return std::string(connection_string.data(), connection_string.length());
 }
 
 PostgresCatalog::~PostgresCatalog() = default;

--- a/src/storage/postgres_connection_pool.cpp
+++ b/src/storage/postgres_connection_pool.cpp
@@ -42,7 +42,7 @@ PostgresPoolConnection PostgresConnectionPool::GetConnection() {
 }
 
 std::unique_ptr<PostgresConnection> PostgresConnectionPool::CreateNewConnection() {
-	auto conn = PostgresConnection::Open(postgres_catalog.connection_string, postgres_catalog.attach_path);
+	auto conn = PostgresConnection::Open(postgres_catalog.GetConnectionString(), postgres_catalog.attach_path);
 	return make_uniq<PostgresConnection>(std::move(conn));
 }
 

--- a/test/sql/storage/attach_rds_iam.test
+++ b/test/sql/storage/attach_rds_iam.test
@@ -1,0 +1,36 @@
+# name: test/sql/storage/attach_rds_iam.test
+# description: Test attaching to AWS RDS using IAM authentication
+# group: [storage]
+
+require postgres_scanner
+
+require-env AWS_RDS_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+CREATE TEMPORARY SECRET rds_secret (
+	TYPE POSTGRES,
+	HOST 'database-1-instance-1.xxxxxxxxxxx.eu-west-1.rds.amazonaws.com',
+  PORT '5432',
+  USER 'postgres',
+  DATABASE 'postgres',
+  SSLMODE 'require',
+  AWS_RDS_IAM_AUTH_ENABLED TRUE,
+  AWS_REGION 'eu-west-1'
+);
+
+statement ok
+ATTACH '' AS rds_attached (TYPE POSTGRES, SECRET rds_secret)
+
+query I
+FROM postgres_query('rds_attached', 'SELECT current_user')
+----
+postgres
+
+statement ok
+DROP SECRET rds_secret
+
+statement ok
+DETACH rds_attached

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,13 @@
 {
   "dependencies": [
     "openssl",
-    "libpq"
+    "libpq",
+    {
+      "name": "aws-sdk-cpp",
+      "features": [
+        "rds"
+      ]
+    }
   ],
   "vcpkg-configuration": {
     "overlay-ports": [


### PR DESCRIPTION
This PR is based on the PR #386.

It uses AWS C++ SDK instead of the AWS CLI to refresh the IAM token automatically.

Configuration example (see details in README):

```sql
CREATE SECRET rds_secret (
    TYPE postgres,
    HOST 'my-db-instance.xxxxxx.us-west-2.rds.amazonaws.com',
    PORT 5432,
    USER 'my_iam_user',
    DATABASE 'mydb',
    SSLMODE require,
    AWS_RDS_IAM_AUTH_ENABLED TRUE,
    AWS_REGION 'us-west-2'
);

ATTACH '' AS rds_db (TYPE postgres, SECRET rds_secret);
```

Testing: the change is tested manually with Aurora, there is currently no AWS testing on CI.

Fixes: #360