### PR TITLE
Support connection URI in SECRETs

### DIFF
--- a/src/include/postgres_secrets.hpp
+++ b/src/include/postgres_secrets.hpp
@@ -14,7 +14,7 @@
 namespace duckdb {
 
 struct PostgresSecrets {
-	static const std::vector<std::string> &KeyNames();
+	static const std::vector<std::string> &ConnectionOptionNames();
 
 	static unique_ptr<BaseSecret> CreateFunction(ClientContext &context, CreateSecretInput &input);
 

--- a/src/postgres_secrets.cpp
+++ b/src/postgres_secrets.cpp
@@ -7,7 +7,7 @@
 namespace duckdb {
 
 // clang-format off
-static const std::vector<std::string> key_names = {
+static const std::vector<std::string> connection_option_names = {
   "host",
   "hostaddr",
   "port",
@@ -61,23 +61,27 @@ static const std::vector<std::string> key_names = {
   "oauth_scope"
 };
 
-static const std::unordered_map<std::string, std::string> key_aliases = {
+static const std::unordered_map<std::string, std::string> connection_option_aliases = {
   {"database", "dbname"},
   {"hostname", "host"},
   {"username", "user"}
 };
+
+static const std::vector<std::string> other_option_names = {
+  "uri"
+};
 // clang-format on
 
 static const std::string &ResolveAlias(const std::string &input_name) {
-	auto it = key_aliases.find(input_name);
-	if (it == key_aliases.end()) {
+	auto it = connection_option_aliases.find(input_name);
+	if (it == connection_option_aliases.end()) {
 		return input_name;
 	}
 	return it->second;
 }
 
-const std::vector<std::string> &PostgresSecrets::KeyNames() {
-	return key_names;
+const std::vector<std::string> &PostgresSecrets::ConnectionOptionNames() {
+	return connection_option_names;
 }
 
 unique_ptr<BaseSecret> PostgresSecrets::CreateFunction(ClientContext &context, CreateSecretInput &input) {
@@ -86,22 +90,27 @@ unique_ptr<BaseSecret> PostgresSecrets::CreateFunction(ClientContext &context, C
 	for (const auto &named_param : input.options) {
 		auto input_name = StringUtil::Lower(named_param.first);
 		auto name = ResolveAlias(input_name);
-		if (std::find(key_names.begin(), key_names.end(), name) == key_names.end()) {
+		if (std::find(connection_option_names.begin(), connection_option_names.end(), name) ==
+		        connection_option_names.end() &&
+		    std::find(other_option_names.begin(), other_option_names.end(), name) == other_option_names.end()) {
 			throw InternalException("Unknown named parameter for a Postgres secret: '" + named_param.first + "'");
 		}
 		result->secret_map[name] = named_param.second.ToString();
 	}
 	//! Set redact keys
-	result->redact_keys = {"password", "sslpassword", "oauth_client_secret"};
+	result->redact_keys = {"password", "sslpassword", "oauth_client_secret", "uri"};
 	return std::move(result);
 }
 
 void PostgresSecrets::SetSecretParameters(CreateSecretFunction &function) {
-	for (const std::string &name : key_names) {
+	for (const std::string &name : connection_option_names) {
 		function.named_parameters[name] = LogicalType::VARCHAR;
 	}
-	for (auto &en : key_aliases) {
+	for (auto &en : connection_option_aliases) {
 		function.named_parameters[en.first] = LogicalType::VARCHAR;
+	}
+	for (const std::string &name : other_option_names) {
+		function.named_parameters[name] = LogicalType::VARCHAR;
 	}
 }
 

--- a/src/storage/postgres_catalog.cpp
+++ b/src/storage/postgres_catalog.cpp
@@ -71,20 +71,39 @@ unique_ptr<SecretEntry> GetSecret(ClientContext &context, const string &secret_n
 
 string PostgresCatalog::GetConnectionString(ClientContext &context, const string &attach_path, string secret_name) {
 	// if no secret is specified we default to the unnamed postgres secret, if it exists
-	string connection_string = attach_path;
 	bool explicit_secret = !secret_name.empty();
 	if (!explicit_secret) {
 		// look up settings from the default unnamed postgres secret if none is provided
 		secret_name = "__default_postgres";
 	}
 
+	string connection_string = attach_path;
 	auto secret_entry = GetSecret(context, secret_name);
 	if (secret_entry) {
 		// secret found - read data
 		const auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*secret_entry->secret);
+
+		// if URI is specified, we use it as a connection string
+		Value uri_val = kv_secret.TryGetValue("uri");
+		if (!uri_val.IsNull()) {
+			// no other options can be specified along with the URI
+			for (const string opt_name : PostgresSecrets::ConnectionOptionNames()) {
+				if (!kv_secret.TryGetValue(opt_name).IsNull()) {
+					throw BinderException("Options with name \"%s\" cannot be specified when 'URI' option is specified",
+					                      opt_name);
+				}
+			}
+			// attach path must be empty
+			if (!attach_path.empty()) {
+				throw BinderException("ATTACH path must be empty when 'URI' option is specified, was: \"%s\"",
+				                      attach_path);
+			}
+			return uri_val.ToString();
+		}
+
 		string new_connection_info;
-		for (const string key_name : PostgresSecrets::KeyNames()) {
-			new_connection_info += AddConnectionOption(kv_secret, key_name);
+		for (const string opt_name : PostgresSecrets::ConnectionOptionNames()) {
+			new_connection_info += AddConnectionOption(kv_secret, opt_name);
 		}
 		connection_string = new_connection_info + connection_string;
 	} else if (explicit_secret) {

--- a/test/sql/storage/attach_secret.test
+++ b/test/sql/storage/attach_secret.test
@@ -43,6 +43,9 @@ SELECT path FROM duckdb_databases() WHERE database_name='secret_attach'
 statement ok
 DETACH secret_attach
 
+statement ok
+DROP SECRET postgres_db;
+
 # all options
 statement ok
 CREATE OR REPLACE SECRET postgres_db (
@@ -103,6 +106,58 @@ CREATE OR REPLACE SECRET postgres_db (
 	HOSTNAME '',
 	USERNAME ''
 );
+
+statement ok
+DROP SECRET postgres_db;
+
+# attach with URI
+statement ok
+CREATE OR REPLACE SECRET postgres_db (
+	TYPE POSTGRES,
+	URI 'postgresql://postgres:postgres@localhost:5432/postgresscanner'
+);
+
+statement ok
+ATTACH '' AS secret_attach (TYPE POSTGRES, SECRET postgres_db)
+
+query I
+SELECT path FROM duckdb_databases() WHERE database_name='secret_attach'
+----
+(empty)
+
+statement ok
+DETACH secret_attach
+
+statement ok
+DROP SECRET postgres_db;
+
+# URI mixed with other options
+statement ok
+CREATE OR REPLACE SECRET postgres_db (
+	TYPE POSTGRES,
+	URI 'foo',
+	HOST 'bar'
+);
+
+statement error
+ATTACH '' AS secret_attach (TYPE POSTGRES, SECRET postgres_db)
+----
+'URI' option
+
+statement ok
+DROP SECRET postgres_db;
+
+# URI mixed non-empty attach path
+statement ok
+CREATE OR REPLACE SECRET postgres_db (
+	TYPE POSTGRES,
+	URI 'foo'
+);
+
+statement error
+ATTACH 'bar' AS secret_attach (TYPE POSTGRES, SECRET postgres_db)
+----
+'URI' option
 
 statement ok
 DROP SECRET postgres_db;


### PR DESCRIPTION
This PR adds support for specifying the
[connection URI](https://www.postgresql.org/docs/18/libpq-connect.html?utm_source=chatgpt.com#LIBPQ-CONNSTRING-URIS) instead of connection options in the `SECRET` definitions, example:

```sql
CREATE OR REPLACE SECRET my_secret (
    TYPE POSTGRES,
    URI 'postgresql://user1:pwd1@localhost:5432/mydb1?target_session_attrs=any&application_name=myapp'
);
ATTACH '' AS p1 (TYPE POSTGRES, secret my_secret);
```

When `URI` is specified in a `SECRET`, the `ATTACH` path must be empty, and no other connection options can be specified.

See #458 for supported connection options.

Fixes: #307