### PR TITLE
Add OpenSSL initialization on-load

### DIFF
--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -1,5 +1,7 @@
 #define DUCKDB_BUILD_LOADABLE_EXTENSION
 #include "duckdb.hpp"
+#include <openssl/crypto.h>
+#include <openssl/ssl.h>
 
 #include "postgres_scanner.hpp"
 #include "postgres_storage.hpp"
@@ -116,6 +118,12 @@ static std::string CreatePoolNote(const std::string &option) {
 }
 
 static void LoadInternal(ExtensionLoader &loader) {
+	// Prevent a race with OpenSSL init that manifests itself with
+	// the following message on the first connection attempt:
+	// "port 5432 failed: could not create SSL context: unknown option"
+	OPENSSL_init_crypto(0, nullptr);
+	OPENSSL_init_ssl(0, nullptr);
+
 	// Register the OAuth bearer token hook before any connections are made
 	PostgresInitOAuthHook();
 


### PR DESCRIPTION
The extension links OpenSSL statically along with the libpq.

In some environments the following error is thrown on the first SSL connection:

```
port 5432 failed: could not create SSL context: unknown option
```

Subsequent connections work correctly.

The root cause is unclear, but it is suspected that some kind of race is happening with OpenSSL initialization on the first use from libpq.

This PR adds explicit initialization on extension load time, with it the problem was not observed.