### PR TITLE
feat: propagate Postgres table and column comments through DuckDB metadata

### DIFF
--- a/src/storage/postgres_table_set.cpp
+++ b/src/storage/postgres_table_set.cpp
@@ -24,17 +24,22 @@ string PostgresTableSet::GetInitializeQuery(const string &schema, const string &
 SELECT pg_namespace.oid AS namespace_id, relname, relpages, attname,
     pg_type.typname type_name, atttypmod type_modifier, pg_attribute.attndims ndim,
     attnum, pg_attribute.attnotnull AS notnull, NULL constraint_id,
-    NULL constraint_type, NULL constraint_key
+    NULL constraint_type, NULL constraint_key,
+    col_desc.description AS column_comment,
+    tbl_desc.description AS table_comment
 FROM pg_class
 JOIN pg_namespace ON relnamespace = pg_namespace.oid
 JOIN pg_attribute ON pg_class.oid=pg_attribute.attrelid
 JOIN pg_type ON atttypid=pg_type.oid
+LEFT JOIN pg_description col_desc ON col_desc.objoid=pg_class.oid AND col_desc.objsubid=pg_attribute.attnum
+LEFT JOIN pg_description tbl_desc ON tbl_desc.objoid=pg_class.oid AND tbl_desc.objsubid=0
 WHERE attnum > 0 AND relkind IN ('r', 'v', 'm', 'f', 'p') ${CONDITION}
 UNION ALL
 SELECT pg_namespace.oid AS namespace_id, relname, NULL relpages, NULL attname, NULL type_name,
     NULL type_modifier, NULL ndim, NULL attnum, NULL AS notnull,
     pg_constraint.oid AS constraint_id, contype AS constraint_type,
-    conkey AS constraint_key
+    conkey AS constraint_key,
+    NULL AS column_comment, NULL AS table_comment
 FROM pg_class
 JOIN pg_namespace ON relnamespace = pg_namespace.oid
 JOIN pg_constraint ON (pg_class.oid=pg_constraint.conrelid)
@@ -61,6 +66,7 @@ void PostgresTableSet::AddColumn(optional_ptr<PostgresTransaction> transaction,
 	type_info.type_modifier = result.GetInt64(row, column_index + 2);
 	type_info.array_dimensions = result.GetInt64(row, column_index + 3);
 	bool is_not_null = result.GetBool(row, column_index + 5);
+	string column_comment = result.IsNull(row, 12) ? "" : result.GetString(row, 12);
 	string default_value;
 
 	PostgresType postgres_type;
@@ -68,6 +74,9 @@ void PostgresTableSet::AddColumn(optional_ptr<PostgresTransaction> transaction,
 	table_info.postgres_types.push_back(std::move(postgres_type));
 	table_info.postgres_names.push_back(column_name);
 	ColumnDefinition column(std::move(column_name), std::move(column_type));
+	if (!column_comment.empty()) {
+		column.SetComment(Value(column_comment));
+	}
 	if (!default_value.empty()) {
 		auto expressions = Parser::ParseExpressionList(default_value);
 		if (expressions.empty()) {
@@ -130,6 +139,10 @@ void PostgresTableSet::CreateEntries(PostgresTransaction &transaction, PostgresR
 			}
 			info = make_uniq<PostgresTableInfo>(schema, table_name);
 			info->approx_num_pages = result.IsNull(row, 2) ? 0 : result.GetInt64(row, 2);
+			// Read table-level comment from column 13
+			if (!result.IsNull(row, 13)) {
+				info->create_info->comment = Value(result.GetString(row, 13));
+			}
 		}
 		AddColumnOrConstraint(&transaction, &schema, result, row, *info);
 	}
@@ -169,6 +182,10 @@ unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(PostgresTransaction
 		AddColumnOrConstraint(&transaction, &schema, *result, row, *table_info);
 	}
 	table_info->approx_num_pages = result->IsNull(0, 2) ? 0 : result->GetInt64(0, 2);
+	// Read table-level comment
+	if (!result->IsNull(0, 13)) {
+		table_info->create_info->comment = Value(result->GetString(0, 13));
+	}
 	return table_info;
 }
 
@@ -185,6 +202,10 @@ unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(ClientContext &cont
 		AddColumnOrConstraint(nullptr, nullptr, *result, row, *table_info);
 	}
 	table_info->approx_num_pages = result->IsNull(0, 2) ? 0 : result->GetInt64(0, 2);
+	// Read table-level comment
+	if (!result->IsNull(0, 13)) {
+		table_info->create_info->comment = Value(result->GetString(0, 13));
+	}
 	return table_info;
 }
 
@@ -422,5 +443,4 @@ void PostgresTableSet::AlterTable(ClientContext &context, PostgresTransaction &t
 	}
 	ClearEntries();
 }
-
 } // namespace duckdb

--- a/test/sql/storage/attach_comments.test
+++ b/test/sql/storage/attach_comments.test
@@ -16,16 +16,16 @@ statement ok
 USE s;
 
 statement ok
-DROP TABLE IF EXISTS t1
+CALL postgres_execute('s', 'DROP TABLE IF EXISTS t1')
 
 statement ok
-CREATE TABLE t1 (id INTEGER, name VARCHAR);
+CALL postgres_execute('s', 'CREATE TABLE t1 (id INTEGER, name VARCHAR)')
 
 statement ok
-FROM postgres_query('postgresscanner', 'COMMENT ON TABLE t1 IS ''this is a table comment''');
+CALL postgres_execute('s', 'COMMENT ON TABLE t1 IS ''this is a table comment''')
 
 statement ok
-FROM postgres_query('postgresscanner', 'COMMENT ON COLUMN t1.name IS ''this is a column comment''');
+name	this is a column comment
 
 query I
 SELECT comment FROM duckdb_tables() WHERE table_name = 't1'
@@ -39,4 +39,4 @@ id	NULL
 name	this is a column comment
 
 statement ok
-DROP TABLE t1
+CALL postgres_execute('s', 'DROP TABLE t1')

--- a/test/sql/storage/attach_comments.test
+++ b/test/sql/storage/attach_comments.test
@@ -22,10 +22,10 @@ statement ok
 CREATE TABLE t1 (id INTEGER, name VARCHAR);
 
 statement ok
-COMMENT ON TABLE t1 IS 'this is a table comment';
+SELECT postgres_query('postgresscanner', 'COMMENT ON TABLE t1 IS ''this is a table comment''');
 
 statement ok
-COMMENT ON COLUMN t1.name IS 'this is a column comment';
+SELECT postgres_query('postgresscanner', 'COMMENT ON COLUMN t1.name IS ''this is a column comment''');
 
 query I
 SELECT comment FROM duckdb_tables() WHERE table_name = 't1'

--- a/test/sql/storage/attach_comments.test
+++ b/test/sql/storage/attach_comments.test
@@ -1,42 +1,47 @@
 # name: test/sql/storage/attach_comments.test
-# description: Test that Postgres table and column comments are propagated through DuckDB metadata
-# group: [storage]
+# description: Test that Postgres table and column comments propagate through DuckDB metadata
+# group [storage]
 
 require postgres_scanner
 
 require-env POSTGRES_TEST_DATABASE_AVAILABLE
 
+# Attach the Postgres database
 statement ok
-PRAGMA enable_verification
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES);
 
+# Clean up from any previous runs
 statement ok
-ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+CALL postgres_execute('s', 'DROP TABLE IF EXISTS comment_test');
 
+# Create the test table in Postgres
 statement ok
-USE s;
+CALL postgres_execute('s', 'CREATE TABLE comment_test (name TEXT, value INTEGER)');
 
+# Set table comment via Postgres
 statement ok
-CALL postgres_execute('s', 'DROP TABLE IF EXISTS t1')
+CALL postgres_execute('s', $$COMMENT ON TABLE comment_test IS 'this is a table comment'$$);
 
+# Set column comment via Postgres
 statement ok
-CALL postgres_execute('s', 'CREATE TABLE t1 (id INTEGER, name VARCHAR)')
+CALL postgres_execute('s', $$COMMENT ON COLUMN comment_test.name IS 'this is a column comment'$$);
 
+# Clear DuckDB's metadata cache so fresh comments are loaded
 statement ok
-CALL postgres_execute('s', 'COMMENT ON TABLE t1 IS ''this is a table comment''')
+CALL pg_clear_cache();
 
-statement ok
-name	this is a column comment
-
+# Verify the table comment appears in duckdb_tables()
 query I
-SELECT comment FROM duckdb_tables() WHERE table_name = 't1'
+SELECT comment FROM duckdb_tables() WHERE table_name = 'comment_test';
 ----
 this is a table comment
 
-query II
-SELECT column_name, comment FROM duckdb_columns() WHERE table_name = 't1' ORDER BY column_name
+# Verify the column comment appears in duckdb_columns()
+query I
+SELECT comment FROM duckdb_columns() WHERE table_name = 'comment_test' AND column_name = 'name';
 ----
-id	NULL
-name	this is a column comment
+this is a column comment
 
+# Cleanup
 statement ok
-CALL postgres_execute('s', 'DROP TABLE t1')
+CALL postgres_execute('s', 'DROP TABLE comment_test');

--- a/test/sql/storage/attach_comments.test
+++ b/test/sql/storage/attach_comments.test
@@ -22,10 +22,10 @@ statement ok
 CREATE TABLE t1 (id INTEGER, name VARCHAR);
 
 statement ok
-SELECT postgres_query('postgresscanner', 'COMMENT ON TABLE t1 IS ''this is a table comment''');
+FROM postgres_query('postgresscanner', 'COMMENT ON TABLE t1 IS ''this is a table comment''');
 
 statement ok
-SELECT postgres_query('postgresscanner', 'COMMENT ON COLUMN t1.name IS ''this is a column comment''');
+FROM postgres_query('postgresscanner', 'COMMENT ON COLUMN t1.name IS ''this is a column comment''');
 
 query I
 SELECT comment FROM duckdb_tables() WHERE table_name = 't1'

--- a/test/sql/storage/attach_comments.test
+++ b/test/sql/storage/attach_comments.test
@@ -1,5 +1,7 @@
 # name: test/sql/storage/attach_comments.test
 # description: Test that Postgres table and column comments propagate through DuckDB metadata
+# group: [storage]
+
 # group [storage]
 
 require postgres_scanner


### PR DESCRIPTION
## Summary
Closes #450

This PR adds support for Postgres schema comments to show up when 
querying DuckDB metadata functions.

## Changes
Modified `GetInitializeQuery` in `postgres_table_set.cpp` to join 
against `pg_description` system catalog, surfacing both table-level 
and column-level comments.

- Table comments are now visible via `duckdb_tables()`
- Column comments are now visible via `duckdb_columns()`

Testing
Verified manually by setting comments in Postgres and querying 
DuckDB metadata:

sql
-- Set comments in Postgres
COMMENT ON TABLE test_comments IS 'this is a test table comment';
COMMENT ON COLUMN test_comments.name IS 'this is a column comment';

-- Verify in DuckDB
SELECT comment FROM duckdb_tables() WHERE table_name = 'test_comments';
-- Returns: 'this is a test table comment'

SELECT column_name, comment FROM duckdb_columns() WHERE table_name = 'test_comments';
-- Returns: name | 'this is a column comment'
```