### PR TITLE
Add collation to constant comparisons

### DIFF
--- a/src/postgres_filter_pushdown.cpp
+++ b/src/postgres_filter_pushdown.cpp
@@ -76,7 +76,11 @@ string PostgresFilterPushdown::TransformConstantFilter(string &column_name, Cons
 		constant_string = TransformLiteral(constant_filter.constant);
 	}
 	auto operator_string = TransformComparison(constant_filter.comparison_type);
-	return StringUtil::Format("%s %s %s", column_name, operator_string, constant_string);
+	string comparison = StringUtil::Format("%s %s %s", column_name, operator_string, constant_string);
+	if (constant_filter.constant.type().id() == LogicalTypeId::VARCHAR) {
+		comparison += " COLLATE \"C\"";
+	}
+	return comparison;
 }
 
 string PostgresFilterPushdown::TransformFilter(string &column_name, TableFilter &filter, column_t column_id) {

--- a/test/sql/storage/attach_like.test
+++ b/test/sql/storage/attach_like.test
@@ -1,0 +1,51 @@
+# name: test/sql/storage/attach_like.test
+# description: Test LIKE statement
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s1 (TYPE POSTGRES)
+
+statement ok
+USE s1
+
+statement ok
+CREATE OR REPLACE TABLE like_test (col1 VARCHAR)
+
+statement ok
+INSERT INTO like_test VALUES ('foo8bar'),('foo9bar'),('Здра9вейте')
+
+query I
+FROM like_test WHERE col1 LIKE 'foo8%';
+----
+foo8bar
+
+query I
+FROM like_test WHERE col1 LIKE 'foo9%';
+----
+foo9bar
+
+query I
+FROM like_test WHERE col1 LIKE 'Здра%';
+----
+Здра9вейте
+
+query I
+FROM like_test WHERE col1 LIKE 'Здра9%';
+----
+Здра9вейте
+
+statement ok
+DROP TABLE like_test
+
+statement ok
+USE memory
+
+statement ok
+DETACH s1


### PR DESCRIPTION
This PR adds `C` collation to generated constant comparison pushdowns. This allows to avoid the problem with collation sensitive comparison when the `LIKE` operator is transformed to comparison by the optimizer.

Fixes: #364
Fixes: #462