### PR TITLE
enable use_information_schema for ATTACH (1.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ cmake-build-debug
 .vscode
 .cache
 duckdb_unittest_tempdir
+.envrc
+docker-compose.yml

--- a/src/include/postgres_utils.hpp
+++ b/src/include/postgres_utils.hpp
@@ -62,6 +62,8 @@ class PostgresUtils {
 public:
 	static PGconn *PGConnect(const string &dsn, const string &attach_path);
 
+	static bool UseInformationSchemaIntrospection(optional_ptr<ClientContext> context);
+	static string DataTypeToTypeName(const string &data_type);
 	static LogicalType ToPostgresType(const LogicalType &input);
 	static LogicalType TypeToLogicalType(optional_ptr<PostgresTransaction> transaction,
 	                                     optional_ptr<PostgresSchemaEntry> schema, const PostgresTypeData &input,

--- a/src/include/storage/postgres_schema_set.hpp
+++ b/src/include/storage/postgres_schema_set.hpp
@@ -22,9 +22,11 @@ public:
 	optional_ptr<CatalogEntry> CreateSchema(PostgresTransaction &transaction, CreateSchemaInfo &info);
 
 	static string GetInitializeQuery(const string &schema = string());
+	static string GetInitializeQueryInformationSchema(const string &schema = string());
 
 protected:
 	void LoadEntries(ClientContext &context, PostgresTransaction &transaction) override;
+	void LoadEntriesInformationSchema(ClientContext &context, PostgresTransaction &transaction);
 
 protected:
 	//! Schema to load - if empty loads all schemas (default behavior)

--- a/src/include/storage/postgres_table_set.hpp
+++ b/src/include/storage/postgres_table_set.hpp
@@ -33,6 +33,7 @@ public:
 	void AlterTable(ClientContext &context, PostgresTransaction &transaction, AlterTableInfo &info);
 
 	static string GetInitializeQuery(const string &schema = string(), const string &table = string());
+	static string GetInitializeQueryInformationSchema(const string &schema = string(), const string &table = string());
 
 protected:
 	void LoadEntries(ClientContext &context, PostgresTransaction &transaction) override;

--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -208,6 +208,11 @@ static void LoadInternal(ExtensionLoader &loader) {
 	                          "Whether or not to use TEXT protocol to read data. This is slower, but provides better "
 	                          "compatibility with non-Postgres systems",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(false));
+	config.AddExtensionOption(
+	    "pg_use_information_schema_introspection",
+	    "Use SQL-standard information_schema views for ATTACH-time schema discovery instead of pg_catalog."
+	    "For compatibility with pg protocol compatible databases like spanner, cockroach, redshift, ...",
+	    LogicalType::BOOLEAN, Value::BOOLEAN(false), PostgresClearCacheFunction::ClearCacheOnSetting);
 	config.AddExtensionOption("pg_statement_timeout_millis",
 	                          "Postgres statement timeout in milliseconds to set on scan connections",
 	                          LogicalType::UINTEGER, Value());

--- a/src/postgres_utils.cpp
+++ b/src/postgres_utils.cpp
@@ -75,6 +75,53 @@ LogicalType PostgresUtils::RemoveAlias(const LogicalType &type) {
 	}
 }
 
+bool PostgresUtils::UseInformationSchemaIntrospection(optional_ptr<ClientContext> context) {
+	if (!context) {
+		return false;
+	}
+	Value value;
+	if (context->TryGetCurrentSetting("pg_use_information_schema_introspection", value)) {
+		return BooleanValue::Get(value);
+	}
+	return false;
+}
+
+string PostgresUtils::DataTypeToTypeName(const string &data_type) {
+	// Map SQL-standard information_schema.columns.data_type values to the
+	// pg_type.typname
+	auto type_name = StringUtil::Lower(data_type);
+	if (type_name == "boolean") {
+		return "bool";
+	} else if (type_name == "smallint") {
+		return "int2";
+	} else if (type_name == "integer") {
+		return "int4";
+	} else if (type_name == "bigint") {
+		return "int8";
+	} else if (type_name == "real") {
+		return "float4";
+	} else if (type_name == "double precision") {
+		return "float8";
+	} else if (type_name == "character varying") {
+		return "varchar";
+	} else if (type_name == "character") {
+		return "bpchar";
+	} else if (type_name == "\"char\"") {
+		return "char";
+	} else if (type_name == "time without time zone") {
+		return "time";
+	} else if (type_name == "time with time zone") {
+		return "timetz";
+	} else if (type_name == "timestamp without time zone") {
+		return "timestamp";
+	} else if (type_name == "timestamp with time zone") {
+		return "timestamptz";
+	} else if (type_name == "bit varying") {
+		return "varbit";
+	}
+	return data_type;
+}
+
 uint32_t PostgresUtils::TypeNameToPostgresOid(const string &type_name) {
 	if (type_name == "bool") {
 		return BOOLOID;
@@ -236,8 +283,9 @@ LogicalType PostgresUtils::TypeToLogicalType(optional_ptr<PostgresTransaction> t
 		postgres_type.info = PostgresTypeAnnotation::GEOM_CIRCLE;
 		return LogicalType::LIST(LogicalType::DOUBLE);
 	} else {
-		if (!transaction) {
-			// unsupported so fallback to varchar
+		if (!transaction || type_info.type_schema.empty()) {
+			// unsupported, or no type schema to resolve custom types in
+			// (information_schema introspection) - fallback to varchar
 			postgres_type.info = PostgresTypeAnnotation::CAST_TO_VARCHAR;
 			return LogicalType::VARCHAR;
 		}

--- a/src/storage/postgres_schema_set.cpp
+++ b/src/storage/postgres_schema_set.cpp
@@ -34,6 +34,29 @@ vector<unique_ptr<PostgresResultSlice>> SliceResult(PostgresResult &schemas, uni
 	return result;
 }
 
+// Variant of SliceResult
+// uses field name instead of an integer oid.
+// Used by the information_schema introspection path where namespace oids are'nt available.
+static vector<unique_ptr<PostgresResultSlice>> SliceResultByName(PostgresResult &schemas,
+                                                                 unique_ptr<PostgresResult> to_slice_ptr) {
+	auto shared_result = shared_ptr<PostgresResult>(to_slice_ptr.release());
+	auto &to_slice = *shared_result;
+
+	vector<unique_ptr<PostgresResultSlice>> result;
+	idx_t current_offset = 0;
+	for (idx_t schema_idx = 0; schema_idx < schemas.Count(); schema_idx++) {
+		auto name = schemas.GetString(schema_idx, 0);
+		idx_t start = current_offset;
+		for (; current_offset < to_slice.Count(); current_offset++) {
+			if (to_slice.GetString(current_offset, 0) != name) {
+				break;
+			}
+		}
+		result.push_back(make_uniq<PostgresResultSlice>(shared_result, start, current_offset));
+	}
+	return result;
+}
+
 string PostgresSchemaSet::GetInitializeQuery(const string &schema) {
 	string base_query = R"(
 SELECT oid, nspname
@@ -48,7 +71,58 @@ ORDER BY oid;
 	return StringUtil::Replace(base_query, "${CONDITION}", condition);
 }
 
+string PostgresSchemaSet::GetInitializeQueryInformationSchema(const string &schema) {
+	string base_query = R"(
+SELECT schema_name
+FROM information_schema.schemata
+WHERE schema_name NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
+${CONDITION}
+ORDER BY schema_name;
+)";
+	string condition;
+	if (!schema.empty()) {
+		condition += "AND schema_name=" + KeywordHelper::WriteQuoted(schema);
+	}
+	return StringUtil::Replace(base_query, "${CONDITION}", condition);
+}
+
+void PostgresSchemaSet::LoadEntriesInformationSchema(ClientContext &context, PostgresTransaction &transaction) {
+	string schema_query = GetInitializeQueryInformationSchema(schema_to_load);
+	string tables_query = PostgresTableSet::GetInitializeQueryInformationSchema(schema_to_load);
+	// Reading enums, composite types and indexes differs across DBs that emulate PG
+	// choice to either return those empty or have vendor specific queries for each.
+	// empty for now
+	string enum_types_query = "SELECT NULL, NULL, NULL, NULL LIMIT 0;\n";
+	string composite_types_query = "SELECT NULL, NULL, NULL, NULL, NULL LIMIT 0;\n";
+	string index_query = "SELECT NULL, NULL, NULL LIMIT 0;\n";
+
+	auto full_query = schema_query + tables_query + enum_types_query + composite_types_query + index_query;
+
+	auto results = transaction.ExecuteQueries(context, full_query);
+	auto result = std::move(results[0]);
+	results.erase(results.begin());
+	auto rows = result->Count();
+
+	auto tables = SliceResultByName(*result, std::move(results[0]));
+	auto enums = SliceResultByName(*result, std::move(results[1]));
+	auto composite_types = SliceResultByName(*result, std::move(results[2]));
+	auto indexes = SliceResultByName(*result, std::move(results[3]));
+	for (idx_t row = 0; row < rows; row++) {
+		auto schema_name = result->GetString(row, 0);
+		CreateSchemaInfo info;
+		info.schema = schema_name;
+		info.internal = PostgresSchemaEntry::SchemaIsInternal(schema_name);
+		auto schema = make_shared_ptr<PostgresSchemaEntry>(catalog, info, std::move(tables[row]), std::move(enums[row]),
+		                                                   std::move(composite_types[row]), std::move(indexes[row]));
+		CreateEntry(transaction, std::move(schema));
+	}
+}
+
 void PostgresSchemaSet::LoadEntries(ClientContext &context, PostgresTransaction &transaction) {
+	if (PostgresUtils::UseInformationSchemaIntrospection(context)) {
+		LoadEntriesInformationSchema(context, transaction);
+		return;
+	}
 	auto &pg_catalog = catalog.Cast<PostgresCatalog>();
 	auto pg_version = pg_catalog.GetPostgresVersion();
 	string schema_query = PostgresSchemaSet::GetInitializeQuery(schema_to_load);

--- a/src/storage/postgres_table_set.cpp
+++ b/src/storage/postgres_table_set.cpp
@@ -57,13 +57,34 @@ ORDER BY namespace_id, relname, attnum, constraint_id;
 	return StringUtil::Replace(base_query, "${CONDITION}", condition);
 }
 
+string PostgresTableSet::GetInitializeQueryInformationSchema(const string &schema, const string &table) {
+	string base_query = R"(
+SELECT table_schema AS namespace_id, table_name AS relname, 0 AS relpages, column_name AS attname,
+    data_type AS type_name, -1 AS type_modifier, 0 AS ndim, ordinal_position AS attnum,
+    CASE WHEN is_nullable = 'NO' THEN 't' ELSE 'f' END AS notnull,
+    NULL AS constraint_id, NULL AS constraint_type, NULL AS constraint_key,
+    NULL AS type_schema, NULL AS column_comment, NULL AS table_comment
+FROM information_schema.columns
+WHERE table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_toast') ${CONDITION}
+ORDER BY table_schema, table_name, ordinal_position;
+)";
+	string condition;
+	if (!schema.empty()) {
+		condition += "AND table_schema=" + KeywordHelper::WriteQuoted(schema);
+	}
+	if (!table.empty()) {
+		condition += " AND table_name=" + KeywordHelper::WriteQuoted(table);
+	}
+	return StringUtil::Replace(base_query, "${CONDITION}", condition);
+}
+
 void PostgresTableSet::AddColumn(optional_ptr<PostgresTransaction> transaction,
                                  optional_ptr<PostgresSchemaEntry> schema, PostgresResult &result, idx_t row,
                                  PostgresTableInfo &table_info) {
 	PostgresTypeData type_info;
 	idx_t column_index = 3;
 	auto column_name = result.GetString(row, column_index);
-	type_info.type_name = result.GetString(row, column_index + 1);
+	type_info.type_name = PostgresUtils::DataTypeToTypeName(result.GetString(row, column_index + 1));
 	type_info.type_modifier = result.GetInt64(row, column_index + 2);
 	type_info.array_dimensions = result.GetInt64(row, column_index + 3);
 	bool is_not_null = result.GetBool(row, column_index + 5);
@@ -165,7 +186,9 @@ void PostgresTableSet::LoadEntries(ClientContext &context, PostgresTransaction &
 		CreateEntries(transaction, table_result->GetResult(), table_result->start, table_result->end);
 		table_result.reset();
 	} else {
-		auto query = GetInitializeQuery(schema.name);
+		auto query = PostgresUtils::UseInformationSchemaIntrospection(context)
+		                 ? GetInitializeQueryInformationSchema(schema.name)
+		                 : GetInitializeQuery(schema.name);
 
 		auto result = transaction.Query(query);
 		auto rows = result->Count();
@@ -176,7 +199,9 @@ void PostgresTableSet::LoadEntries(ClientContext &context, PostgresTransaction &
 
 unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(PostgresTransaction &transaction,
                                                              PostgresSchemaEntry &schema, const string &table_name) {
-	auto query = PostgresTableSet::GetInitializeQuery(schema.name, table_name);
+	auto query = PostgresUtils::UseInformationSchemaIntrospection(transaction.GetContext())
+	                 ? GetInitializeQueryInformationSchema(schema.name, table_name)
+	                 : GetInitializeQuery(schema.name, table_name);
 	auto result = transaction.Query(query);
 	auto rows = result->Count();
 	if (rows == 0) {
@@ -196,7 +221,9 @@ unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(PostgresTransaction
 
 unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(ClientContext &context, PostgresConnection &connection,
                                                              const string &schema_name, const string &table_name) {
-	auto query = PostgresTableSet::GetInitializeQuery(schema_name, table_name);
+	auto query = PostgresUtils::UseInformationSchemaIntrospection(context)
+	                 ? GetInitializeQueryInformationSchema(schema_name, table_name)
+	                 : GetInitializeQuery(schema_name, table_name);
 	auto result = connection.Query(context, query);
 	auto rows = result->Count();
 	if (rows == 0) {

--- a/test/sql/storage/information_schema_introspection.test
+++ b/test/sql/storage/information_schema_introspection.test
@@ -1,0 +1,93 @@
+# name: test/sql/storage/information_schema_introspection.test
+# description: Test pg_use_information_schema_introspection — schema discovery via SQL-standard information_schema instead of pg_catalog
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+# baseline ATTACH (pg_catalog path) — collect the table set for comparison
+statement ok
+ATTACH 'dbname=postgresscanner' AS pgc (TYPE POSTGRES)
+
+# default is false; default path is unchanged
+query I
+SELECT current_setting('pg_use_information_schema_introspection')
+----
+false
+
+# snapshot schema as obtained the pg way
+statement ok
+CREATE TEMP TABLE pgc_tables AS SELECT schema_name, table_name FROM duckdb_tables() WHERE database_name='pgc' AND schema_name NOT IN ('pg_catalog', 'information_schema')
+
+statement ok
+DETACH pgc
+
+statement ok
+SET pg_use_information_schema_introspection=true
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+# the two paths discover the same tables
+query I
+SELECT COUNT(*) FROM (
+  SELECT schema_name, table_name FROM duckdb_tables() WHERE database_name='s'
+  EXCEPT
+  SELECT schema_name, table_name FROM pgc_tables
+)
+----
+0
+
+# query it the other way around to ensure exact match
+query I
+SELECT COUNT(*) FROM (
+  SELECT schema_name, table_name FROM pgc_tables
+  EXCEPT
+  SELECT schema_name, table_name FROM duckdb_tables() WHERE database_name='s'
+)
+----
+0
+
+# round-trip a table with the data_type forms the new path has to map
+statement ok
+DROP TABLE IF EXISTS s.public.is_types
+
+statement ok
+CREATE TABLE s.public.is_types(i BIGINT, name VARCHAR, ts TIMESTAMPTZ, flag BOOLEAN)
+
+statement ok
+INSERT INTO s.public.is_types VALUES (42, 'hello', TIMESTAMPTZ '2024-01-01 00:00:00+00', true)
+
+statement ok
+INSERT INTO s.public.is_types VALUES (NULL, NULL, NULL, NULL)
+
+# force a fresh introspection of the new table
+statement ok
+CALL pg_clear_cache()
+
+query IIII
+SELECT i, name, ts, flag FROM s.public.is_types ORDER BY i NULLS LAST
+----
+42	hello	2024-01-01 00:00:00+00	true
+NULL	NULL	NULL	NULL
+
+# information_schema reports verbose data_type names; verify the mapping landed
+# on the right DuckDB types (bigint→BIGINT, character varying→VARCHAR,
+# timestamp with time zone→TIMESTAMPTZ (which duckdb then reports back as timestamp with timezone), boolean→BOOLEAN)
+query IIII
+SELECT typeof(i), typeof(name), typeof(ts), typeof(flag) FROM s.public.is_types LIMIT 1
+----
+BIGINT	VARCHAR	TIMESTAMP WITH TIME ZONE	BOOLEAN
+
+statement ok
+DROP TABLE s.public.is_types
+
+statement ok
+DETACH s
+
+statement ok
+RESET pg_use_information_schema_introspection


### PR DESCRIPTION
This is a backport of the PR #493 to `v1.5-variegata` stable branch.

PR following the conversation started at #490

I have excluded from the PR handling enums, composite types and indexes that are unfortunately reported differently by different DB vendors.

I see a couple options here:

 - leave ignored for now
 - try to auto-detect the actual DB this is talking to and pick the right queries to get the right info this way
 - change from a `use_info_schema param` to a `pg_compatibility_mode_for=(spanner|redshift|cockroach|...)`

Open to any of those options. Though auto-detection is probably the most brittle.