### PR TITLE
fix: catalog cache loading race

### DIFF
--- a/src/include/storage/postgres_catalog_set.hpp
+++ b/src/include/storage/postgres_catalog_set.hpp
@@ -12,6 +12,7 @@
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/mutex.hpp"
 #include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/thread.hpp"
 
 namespace duckdb {
 struct DropInfo;
@@ -52,6 +53,7 @@ private:
 	unordered_map<string, shared_ptr<CatalogEntry>> entries;
 	case_insensitive_map_t<string> entry_map;
 	atomic<bool> is_loaded;
+	atomic<thread_id> loading_thread;
 };
 
 class PostgresInSchemaSet : public PostgresCatalogSet {

--- a/src/storage/postgres_catalog_set.cpp
+++ b/src/storage/postgres_catalog_set.cpp
@@ -6,7 +6,8 @@
 
 namespace duckdb {
 
-PostgresCatalogSet::PostgresCatalogSet(Catalog &catalog, bool is_loaded_p) : catalog(catalog), is_loaded(is_loaded_p) {
+PostgresCatalogSet::PostgresCatalogSet(Catalog &catalog, bool is_loaded_p)
+    : catalog(catalog), is_loaded(is_loaded_p), loading_thread(thread_id()) {
 }
 
 optional_ptr<CatalogEntry> PostgresCatalogSet::GetEntry(ClientContext &context, PostgresTransaction &transaction,
@@ -44,7 +45,7 @@ optional_ptr<CatalogEntry> PostgresCatalogSet::GetEntry(ClientContext &context, 
 
 void PostgresCatalogSet::TryLoadEntries(ClientContext &context, PostgresTransaction &transaction) {
 	if (HasInternalDependencies()) {
-		if (is_loaded) {
+		if (is_loaded || loading_thread == ThreadUtil::GetThreadId()) {
 			return;
 		}
 	}
@@ -52,8 +53,15 @@ void PostgresCatalogSet::TryLoadEntries(ClientContext &context, PostgresTransact
 	if (is_loaded) {
 		return;
 	}
+	loading_thread = ThreadUtil::GetThreadId();
+	try {
+		LoadEntries(context, transaction);
+	} catch (...) {
+		loading_thread = thread_id();
+		throw;
+	}
 	is_loaded = true;
-	LoadEntries(context, transaction);
+	loading_thread = thread_id();
 }
 
 optional_ptr<CatalogEntry> PostgresCatalogSet::ReloadEntry(PostgresTransaction &transaction, const string &name) {


### PR DESCRIPTION
Resolves #500 

## Problem

Catalog metadata is cached the first time something needs it. A boolean, `is_loaded` tells the process whether or not the cache has already been populated so it doesn;t continually reload. `is_loaded = true` gets set _before_ the actual loading is finished, however. That scenario is often guarded by a lock but a fast path was introduced, skipping the lock, so that a composite type referencing another type in the same catalog doesn't deadlock. When that occurs though, only `is_loaded` is checked without being able to differentiate if it's the intended situation where we're avoiding a deadlock or if it's a completely unrelated thread popping in.

In the latter situation, the new thread skips the lock, sees `is_loaded = true` then starts working through a catalog that's only half-built, ending in a seg fault.

## Fix

Track which thread is inside the catalog load. The fast path can then check not onlu if the loading is done but also if it is the thread working through it's own load. Every other scenario lands on the lock and appropriately waits. And `is_loaded = true` until _after_ completion.

> [!NOTE]
> While digging into this I also happened upon an unrelated bug in DuckDB core where `duckdb_views()` holds onto catalog entries without maintaining them appropriately. This can also lead to a craash if the crash get's cleared with `pg_clear_cache()` mid-scan. So if you're testing this PR, do not be surprised if you implement the fix only to find yourself crashed with a different error message.
