### PR TITLE
fix: prevent catalog scan use-after-free

### DIFF
--- a/src/include/storage/postgres_transaction.hpp
+++ b/src/include/storage/postgres_transaction.hpp
@@ -49,6 +49,7 @@ private:
 	AccessMode access_mode;
 	PostgresIsolationLevel isolation_level;
 	string temporary_schema;
+	mutex referenced_entries_lock;
 	reference_map_t<CatalogEntry, shared_ptr<CatalogEntry>> referenced_entries;
 
 private:

--- a/src/storage/postgres_catalog_set.cpp
+++ b/src/storage/postgres_catalog_set.cpp
@@ -93,6 +93,7 @@ void PostgresCatalogSet::Scan(ClientContext &context, PostgresTransaction &trans
 	TryLoadEntries(context, transaction);
 	lock_guard<mutex> l(entry_lock);
 	for (auto &entry : entries) {
+		transaction.ReferenceEntry(entry.second);
 		callback(*entry.second);
 	}
 }

--- a/src/storage/postgres_transaction.cpp
+++ b/src/storage/postgres_transaction.cpp
@@ -126,6 +126,7 @@ vector<unique_ptr<PostgresResult>> PostgresTransaction::ExecuteQueries(ClientCon
 
 optional_ptr<CatalogEntry> PostgresTransaction::ReferenceEntry(shared_ptr<CatalogEntry> &entry) {
 	auto &ref = *entry;
+	lock_guard<mutex> l(referenced_entries_lock);
 	referenced_entries.emplace(ref, entry);
 	return ref;
 }

--- a/test/sql/storage/catalog_scan_concurrent_clear_stress.test_slow
+++ b/test/sql/storage/catalog_scan_concurrent_clear_stress.test_slow
@@ -1,0 +1,47 @@
+# name: test/sql/storage/catalog_scan_concurrent_clear_stress.test_slow
+# description: Concurrent pg_clear_cache() vs duckdb_tables()/duckdb_indexes() UAF stress repro (run under ASAN)
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+USE s
+
+statement ok
+DROP TABLE IF EXISTS scan_stress_tbl
+
+statement ok
+CREATE TABLE scan_stress_tbl (i INTEGER)
+
+statement ok
+INSERT INTO scan_stress_tbl VALUES (1)
+
+concurrentloop i 0 200
+
+statement maybe
+CALL pg_clear_cache();
+----
+
+statement maybe
+SELECT * FROM duckdb_tables();
+----
+
+statement maybe
+SELECT * FROM duckdb_indexes();
+----
+
+statement maybe
+SELECT * FROM scan_stress_tbl;
+----
+
+endloop
+
+query I
+SELECT * FROM scan_stress_tbl
+----
+1

--- a/test/sql/storage/catalog_scan_entry_survives_clear.test
+++ b/test/sql/storage/catalog_scan_entry_survives_clear.test
@@ -1,0 +1,35 @@
+# name: test/sql/storage/catalog_scan_entry_survives_clear.test
+# description: PostgresCatalogSet::Scan entries must survive a concurrent pg_clear_cache()
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+USE s
+
+statement ok
+DROP TABLE IF EXISTS scan_survives_clear_tbl
+
+statement ok
+CREATE TABLE scan_survives_clear_tbl AS SELECT 1 AS x
+
+query I
+SELECT count(*) >= 0 FROM duckdb_tables()
+----
+1
+
+statement ok
+CALL pg_clear_cache()
+
+query I
+SELECT table_name FROM duckdb_tables() WHERE table_name = 'scan_survives_clear_tbl'
+----
+scan_survives_clear_tbl
+
+statement ok
+DROP TABLE scan_survives_clear_tbl


### PR DESCRIPTION
Resolves #502 

## Problem

`PostgresCatalogSet::Scan` hands its callback a bare `CatalogEntry&` without pinning it into the calling transaction first. `GetEntry` and `CreateEntry` both keep the underlying `shared_ptr<CatalogEntry>` alive in `PostgresTransaction::referenced_entries` for the rest of the transaction. `Scan` does not.

If `pg_clear_cache` runs after a `Scan` but before every reference handed out by that `Scan` is done being used, `ClearEntries` drops the `shared_ptr` for those entries and destroys them. Anything still holding a reference from the earlier `Scan` is then reading freed memory; i.e., funcs from Duckdb core like `duckdb_tables()` or `duckdb_vies()`

## Fix

Pinning every entry into the calling transaction inside `Scan`'s existing lock scope, the same way `GetEntry` and `CreateEntry` already do:

```cpp
for (auto &entry : entries) {
        transaction.ReferenceEntry(entry.second);
        callback(*entry.second);
}
```

`ReferenceEntry`/`referenced_entries` is already the established solution for this exact problem. `Scan` just wasn't using it yet


