### PR TITLE
VARCHAR fallback for types in inaccessible schema

### DIFF
--- a/src/postgres_utils.cpp
+++ b/src/postgres_utils.cpp
@@ -285,35 +285,44 @@ LogicalType PostgresUtils::TypeToLogicalType(optional_ptr<PostgresTransaction> t
 	} else if (pgtypename == "circle") {
 		postgres_type.info = PostgresTypeAnnotation::GEOM_CIRCLE;
 		return LogicalType::LIST(LogicalType::DOUBLE);
+	}
+
+	if (!transaction || !schema || type_info.type_schema.empty()) {
+		// unsupported, or no type schema to resolve custom types in
+		// (information_schema introspection) - fallback to varchar
+		postgres_type.info = PostgresTypeAnnotation::CAST_TO_VARCHAR;
+		return LogicalType::VARCHAR;
+	}
+
+	auto context = transaction->GetContext();
+	if (!context) {
+		throw InternalException("Context is destroyed!?");
+	}
+
+	Identifier type_schema = Identifier(type_info.type_schema);
+	optional_ptr<SchemaCatalogEntry> lookup_schema;
+	if (type_schema == schema->name) {
+		lookup_schema = schema.get();
 	} else {
-		if (!transaction || type_info.type_schema.empty()) {
-			// unsupported, or no type schema to resolve custom types in
-			// (information_schema introspection) - fallback to varchar
-			postgres_type.info = PostgresTypeAnnotation::CAST_TO_VARCHAR;
-			return LogicalType::VARCHAR;
-		}
-		auto context = transaction->GetContext();
-		if (!context) {
-			throw InternalException("Context is destroyed!?");
-		}
-		optional_ptr<SchemaCatalogEntry> lookup_schema =
-		    Identifier(type_info.type_schema) != schema->name
-		        ? schema->ParentCatalog().GetSchema(*context, Identifier(type_info.type_schema),
-		                                            OnEntryNotFound::THROW_EXCEPTION)
-		        : schema.get();
+		Catalog &parent_catalog = schema->ParentCatalog();
+		lookup_schema = parent_catalog.GetSchema(*context, type_schema, OnEntryNotFound::RETURN_NULL);
+	}
+
+	if (lookup_schema) {
 		auto entry = lookup_schema->GetEntry(CatalogTransaction(lookup_schema->ParentCatalog(), *context),
 		                                     CatalogType::TYPE_ENTRY, Identifier(pgtypename));
-		if (!entry) {
-			// unsupported so fallback to varchar
-			postgres_type.info = PostgresTypeAnnotation::CAST_TO_VARCHAR;
-			return LogicalType::VARCHAR;
+		if (entry) {
+			// custom type (e.g. composite or enum)
+			auto &type_entry = entry->Cast<PostgresTypeEntry>();
+			auto result_type = RemoveAlias(type_entry.user_type);
+			postgres_type = type_entry.postgres_type;
+			return result_type;
 		}
-		// custom type (e.g. composite or enum)
-		auto &type_entry = entry->Cast<PostgresTypeEntry>();
-		auto result_type = RemoveAlias(type_entry.user_type);
-		postgres_type = type_entry.postgres_type;
-		return result_type;
 	}
+
+	// either schema or type is not available so fallback to varchar
+	postgres_type.info = PostgresTypeAnnotation::CAST_TO_VARCHAR;
+	return LogicalType::VARCHAR;
 }
 
 LogicalType PostgresUtils::ToPostgresType(const LogicalType &input) {

--- a/test/sql/storage/attach_types_varchar_fallback.test
+++ b/test/sql/storage/attach_types_varchar_fallback.test
@@ -1,0 +1,78 @@
+# name: test/sql/storage/attach_types_varchar_fallback.test
+# description: Test for using types from different schema that must fall back to VARCHAR
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+# prepare schemas
+
+statement ok
+CALL postgres_execute('s', 'DROP SCHEMA IF EXISTS data_s CASCADE')
+
+statement ok
+CALL postgres_execute('s', 'DROP SCHEMA IF EXISTS types_s CASCADE')
+
+statement ok
+CALL postgres_execute('s', 'CREATE SCHEMA types_s')
+
+statement ok
+CALL postgres_execute('s', 'CREATE SCHEMA data_s')
+
+statement ok
+CALL postgres_execute('s', 'CREATE TYPE types_s.mood AS ENUM (''happy'',''sad'')')
+
+statement ok
+CALL postgres_execute('s', 'CREATE TABLE data_s.users (id int, name text)')
+
+statement ok
+CALL postgres_execute('s', 'CREATE TABLE data_s.moods (id int, m types_s.mood)')
+
+statement ok
+CALL postgres_execute('s', 'INSERT INTO data_s.users VALUES (1, ''a'')')
+
+statement ok
+CALL postgres_execute('s', 'INSERT INTO data_s.moods VALUES (1, ''happy'')')
+
+statement ok
+DETACH s
+
+# attach only the data schema
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, SCHEMA data_s, READ_ONLY)
+
+statement ok
+USE s
+
+query I
+SELECT count(*) FROM s.data_s.users
+----
+1
+
+# cleanup
+
+statement ok
+USE memory
+
+statement ok
+DETACH s
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+CALL postgres_execute('s', 'DROP SCHEMA data_s CASCADE')
+
+statement ok
+CALL postgres_execute('s', 'DROP SCHEMA types_s CASCADE')
+
+statement ok
+USE memory
+
+statement ok
+DETACH s


### PR DESCRIPTION
This is a follow-up to #476, it extends the `VARCHAR` fallback logic for types, that are defined in a schema that is different from the attached schema.

Testing: new test added that covers inaccessible schema type.

Ref: #497