### PR TITLE
fix: avoid crash by setting default index constraint type

### DIFF
--- a/src/storage/postgres_index_set.cpp
+++ b/src/storage/postgres_index_set.cpp
@@ -39,6 +39,7 @@ void PostgresIndexSet::LoadEntries(ClientContext &context, PostgresTransaction &
 		auto table_name = result.GetString(row, 1);
 		auto index_name = result.GetString(row, 2);
 		CreateIndexInfo info;
+		info.constraint_type = IndexConstraintType::NONE;
 		info.SetQualifiedName(
 		    QualifiedName(info.GetQualifiedName().Catalog(), schema.name, info.GetQualifiedName().Name()));
 		info.table = Identifier(table_name);

--- a/test/sql/storage/attach_duckdb_indexes_constraint_type.test
+++ b/test/sql/storage/attach_duckdb_indexes_constraint_type.test
@@ -1,0 +1,35 @@
+# name: test/sql/storage/attach_duckdb_indexes_constraint_type.test
+# description: duckdb_indexes() must not crash scanning Postgres indexes (constraint_type uninitialized read)
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+DROP TABLE IF EXISTS s.constraint_type_tbl
+
+statement ok
+CREATE TABLE s.constraint_type_tbl(i INTEGER)
+
+statement ok
+CREATE INDEX constraint_type_idx ON s.constraint_type_tbl(i)
+
+query I
+SELECT count(*) FROM duckdb_indexes() WHERE database_name = 's' AND index_name = 'constraint_type_idx'
+----
+1
+
+query II
+SELECT is_unique, is_primary FROM duckdb_indexes() WHERE database_name = 's' AND index_name = 'constraint_type_idx'
+----
+false	false
+
+statement ok
+DROP INDEX s.constraint_type_idx
+
+statement ok
+DROP TABLE s.constraint_type_tbl


### PR DESCRIPTION
Resolves #507

## Problem

`duckdb_indexes()` scanning an attached Postgres catalog can crash with an internal assertion:

```text
INTERNAL Error: Assertion triggered in file "duckdb/src/parser/parsed_data/create_index_info.cpp" on line 65: constraint_type == IndexConstraintType::UNIQUE || constraint_type == IndexConstraintType::NONE
```

`PostgresIndexSet::LoadEntries` constructs a `CreateIndexInfo` for every Postgres index then lazily loads into the catalog. But it doesn't assign `constraint_type`. Since the field has no default it ends up being whatever garbage memory that happens to be sitting at the address at the time, which then flows straight into the catalog entry. Anything that later calls `ToSQL()`/`ToString()` on it asserts if the value isn't `UNIQUE` or `NONE`. That then causes a crash in some scenario

## Fix

Explicitly initializing `constraint_type` to `NONE` right where the entry is built, the same place every other field on `info` is already set

```cpp
CreateIndexInfo info;
info.constraint_type = IndexConstraintType::NONE;
info.SetQualifiedName(...);
```
