### PR TITLE
Allow ATTACHing to multiple Postgres schemas (1.5)

### DIFF
--- a/src/include/postgres_utils.hpp
+++ b/src/include/postgres_utils.hpp
@@ -81,6 +81,7 @@ public:
 
 	static string EscapeConnectionString(const string &input);
 	static string ExtractConnectionOption(const KeyValueSecret &kv_secret, const string &name);
+	static string WriteLiteralsCommaSeparated(const vector<string> &literals);
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_catalog.hpp
+++ b/src/include/storage/postgres_catalog.hpp
@@ -26,8 +26,8 @@ class PostgresSchemaEntry;
 class PostgresCatalog : public Catalog {
 public:
 	explicit PostgresCatalog(ClientContext &ctx, AttachedDatabase &db_p, string attach_path, AccessMode access_mode,
-	                         string schema_to_load, PostgresIsolationLevel isolation_level, const string &secret_name,
-	                         SecretStorageTable secret_storage_table_p);
+	                         vector<string> schemas_to_load, PostgresIsolationLevel isolation_level,
+	                         const string &secret_name, SecretStorageTable secret_storage_table_p);
 	~PostgresCatalog();
 
 	string attach_path;

--- a/src/include/storage/postgres_index_set.hpp
+++ b/src/include/storage/postgres_index_set.hpp
@@ -20,7 +20,7 @@ public:
 	PostgresIndexSet(PostgresSchemaEntry &schema, unique_ptr<PostgresResultSlice> index_result = nullptr);
 
 public:
-	static string GetInitializeQuery(const string &schema = string());
+	static string GetInitializeQuery(const vector<string> &schemas);
 
 	optional_ptr<CatalogEntry> CreateIndex(PostgresTransaction &transaction, CreateIndexInfo &info,
 	                                       TableCatalogEntry &table);

--- a/src/include/storage/postgres_schema_set.hpp
+++ b/src/include/storage/postgres_schema_set.hpp
@@ -16,13 +16,13 @@ struct CreateSchemaInfo;
 
 class PostgresSchemaSet : public PostgresCatalogSet {
 public:
-	explicit PostgresSchemaSet(Catalog &catalog, string schema_to_load);
+	explicit PostgresSchemaSet(Catalog &catalog, vector<string> schemas_to_load);
 
 public:
 	optional_ptr<CatalogEntry> CreateSchema(PostgresTransaction &transaction, CreateSchemaInfo &info);
 
-	static string GetInitializeQuery(const string &schema = string());
-	static string GetInitializeQueryInformationSchema(const string &schema = string());
+	static string GetInitializeQuery(const vector<string> &schemas);
+	static string GetInitializeQueryInformationSchema(const vector<string> &schemas);
 
 protected:
 	void LoadEntries(ClientContext &context, PostgresTransaction &transaction) override;
@@ -30,7 +30,7 @@ protected:
 
 protected:
 	//! Schema to load - if empty loads all schemas (default behavior)
-	string schema_to_load;
+	vector<string> schemas_to_load;
 };
 
 } // namespace duckdb

--- a/src/include/storage/postgres_table_set.hpp
+++ b/src/include/storage/postgres_table_set.hpp
@@ -33,7 +33,9 @@ public:
 	void AlterTable(ClientContext &context, PostgresTransaction &transaction, AlterTableInfo &info);
 
 	static string GetInitializeQuery(const string &schema = string(), const string &table = string());
+	static string GetInitializeQuery(const vector<string> &schemas, const string &table = string());
 	static string GetInitializeQueryInformationSchema(const string &schema = string(), const string &table = string());
+	static string GetInitializeQueryInformationSchema(const vector<string> &schemas, const string &table = string());
 
 protected:
 	void LoadEntries(ClientContext &context, PostgresTransaction &transaction) override;

--- a/src/include/storage/postgres_type_set.hpp
+++ b/src/include/storage/postgres_type_set.hpp
@@ -25,8 +25,8 @@ public:
 public:
 	optional_ptr<CatalogEntry> CreateType(PostgresTransaction &transaction, CreateTypeInfo &info);
 
-	static string GetInitializeEnumsQuery(PostgresVersion version, const string &schema = string());
-	static string GetInitializeCompositesQuery(const string &schema = string());
+	static string GetInitializeEnumsQuery(PostgresVersion version, const vector<string> &schemas);
+	static string GetInitializeCompositesQuery(const vector<string> &schemas);
 
 protected:
 	bool HasInternalDependencies() const override {

--- a/src/postgres_storage.cpp
+++ b/src/postgres_storage.cpp
@@ -8,6 +8,45 @@
 
 namespace duckdb {
 
+static vector<string> ExtractSchemas(Value &value) {
+	if (value.IsNull()) {
+		throw BinderException("Value for \"SCHEMA\" option must not be null");
+	}
+	switch (value.type().id()) {
+	case LogicalTypeId::VARCHAR: {
+		vector<string> res;
+		const string &name = StringValue::Get(value);
+		if (name.empty()) {
+			throw BinderException("Value \"SCHEMA\" option must be not empty");
+		}
+		res.push_back(name);
+		return res;
+	}
+	case LogicalTypeId::LIST: {
+		if (ListType::GetChildType(value.type()).id() != LogicalTypeId::VARCHAR) {
+			throw BinderException(
+			    "Value for \"SCHEMA\" option must be either \"VARCHAR\" or \"VARCHAR[]\", was: \"%s\"",
+			    value.type().ToString());
+		}
+		vector<string> res;
+		for (const Value &en : ListValue::GetChildren(value)) {
+			if (en.IsNull()) {
+				throw BinderException("Values for \"SCHEMA\" option must not be null");
+			}
+			const string &name = StringValue::Get(en);
+			if (name.empty()) {
+				throw BinderException("Values \"SCHEMA\" option must be not empty");
+			}
+			res.push_back(name);
+		}
+		return res;
+	}
+	default:
+		throw BinderException("Value for `SCHEMA` option must be either \"VARCHAR\" or \"VARCHAR[]\", was: \"%s\"",
+		                      value.type().ToString());
+	}
+}
+
 static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
                                           AttachedDatabase &db, const string &name, AttachInfo &info,
                                           AttachOptions &attach_options) {
@@ -18,7 +57,7 @@ static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> sto
 	string attach_path = info.path;
 
 	string secret_name;
-	string schema_to_load;
+	vector<string> schemas_to_load;
 	PostgresIsolationLevel isolation_level = PostgresIsolationLevel::REPEATABLE_READ;
 	string secret_storage_table_name;
 	bool secret_storage_table_specified_explicitly = false;
@@ -27,7 +66,7 @@ static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> sto
 		if (lower_name == "secret") {
 			secret_name = entry.second.ToString();
 		} else if (lower_name == "schema") {
-			schema_to_load = entry.second.ToString();
+			schemas_to_load = ExtractSchemas(entry.second);
 		} else if (lower_name == "isolation_level") {
 			auto param = entry.second.ToString();
 			auto lparam = StringUtil::Lower(param);
@@ -38,9 +77,9 @@ static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> sto
 			} else if (lparam == "serializable") {
 				isolation_level = PostgresIsolationLevel::SERIALIZABLE;
 			} else {
-				throw InvalidInputException("Invalid value \"%s\" for isolation_level, expected READ COMMITTED, "
-				                            "REPEATABLE READ or SERIALIZABLE",
-				                            param);
+				throw BinderException("Invalid value \"%s\" for isolation_level, expected READ COMMITTED, "
+				                      "REPEATABLE READ or SERIALIZABLE",
+				                      param);
 			}
 		} else if (lower_name == "secret_storage_table") {
 			secret_storage_table_name = entry.second.ToString();
@@ -52,7 +91,7 @@ static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> sto
 	SecretStorageTable secret_storage_table(std::move(secret_storage_table_name),
 	                                        secret_storage_table_specified_explicitly);
 	return make_uniq<PostgresCatalog>(context, db, std::move(attach_path), attach_options.access_mode,
-	                                  std::move(schema_to_load), isolation_level, secret_name,
+	                                  std::move(schemas_to_load), isolation_level, secret_name,
 	                                  std::move(secret_storage_table));
 }
 

--- a/src/postgres_utils.cpp
+++ b/src/postgres_utils.cpp
@@ -629,4 +629,16 @@ string PostgresUtils::ExtractConnectionOption(const KeyValueSecret &kv_secret, c
 	return result;
 }
 
+string PostgresUtils::WriteLiteralsCommaSeparated(const vector<string> &literals) {
+	string res;
+	for (idx_t i = 0; i < literals.size(); i++) {
+		const string &lit = literals[i];
+		if (i > 0) {
+			res.append(", ");
+		}
+		res.append(KeywordHelper::WriteQuoted(lit));
+	}
+	return res;
+}
+
 } // namespace duckdb

--- a/src/storage/postgres_catalog.cpp
+++ b/src/storage/postgres_catalog.cpp
@@ -29,11 +29,13 @@ unique_ptr<SecretEntry> GetSecret(ClientContext &context, const string &secret_n
 }
 
 PostgresCatalog::PostgresCatalog(ClientContext &ctx, AttachedDatabase &db_p, string attach_path_p,
-                                 AccessMode access_mode, string schema_to_load, PostgresIsolationLevel isolation_level,
-                                 const string &secret_name, SecretStorageTable secret_storage_table_p)
+                                 AccessMode access_mode, vector<string> schemas_to_load,
+                                 PostgresIsolationLevel isolation_level, const string &secret_name,
+                                 SecretStorageTable secret_storage_table_p)
     : Catalog(db_p), attach_path(std::move(attach_path_p)), access_mode(access_mode), isolation_level(isolation_level),
-      schemas(*this, schema_to_load), connection_pool(make_shared_ptr<PostgresConnectionPool>(*this, ctx)),
-      default_schema(schema_to_load), secret_storage_table(std::move(secret_storage_table_p)) {
+      schemas(*this, schemas_to_load), connection_pool(make_shared_ptr<PostgresConnectionPool>(*this, ctx)),
+      default_schema(schemas_to_load.size() > 0 ? schemas_to_load[0] : std::string()),
+      secret_storage_table(std::move(secret_storage_table_p)) {
 	auto secret_entry = GetSecretEntry(ctx, secret_name);
 	this->rds_token_config = PostgresAws::ExtractTokenConfigFromSecret(secret_entry);
 	if (!rds_token_config.Enabled()) {

--- a/src/storage/postgres_index_set.cpp
+++ b/src/storage/postgres_index_set.cpp
@@ -12,7 +12,7 @@ PostgresIndexSet::PostgresIndexSet(PostgresSchemaEntry &schema, unique_ptr<Postg
     : PostgresInSchemaSet(schema, !index_result_p), index_result(std::move(index_result_p)) {
 }
 
-string PostgresIndexSet::GetInitializeQuery(const string &schema) {
+string PostgresIndexSet::GetInitializeQuery(const vector<string> &schemas) {
 	string base_query = R"(
 SELECT pg_namespace.oid, tablename, indexname
 FROM pg_indexes
@@ -21,8 +21,8 @@ ${CONDITION}
 ORDER BY pg_namespace.oid;
 )";
 	string condition;
-	if (!schema.empty()) {
-		condition += "WHERE pg_namespace.nspname=" + KeywordHelper::WriteQuoted(schema);
+	if (schemas.size() > 0) {
+		condition += "WHERE pg_namespace.nspname IN (" + PostgresUtils::WriteLiteralsCommaSeparated(schemas) + ")";
 	}
 	return StringUtil::Replace(base_query, "${CONDITION}", condition);
 }

--- a/src/storage/postgres_schema_set.cpp
+++ b/src/storage/postgres_schema_set.cpp
@@ -10,8 +10,8 @@
 
 namespace duckdb {
 
-PostgresSchemaSet::PostgresSchemaSet(Catalog &catalog, string schema_to_load_p)
-    : PostgresCatalogSet(catalog, false), schema_to_load(std::move(schema_to_load_p)) {
+PostgresSchemaSet::PostgresSchemaSet(Catalog &catalog, vector<string> schemas_to_load_p)
+    : PostgresCatalogSet(catalog, false), schemas_to_load(std::move(schemas_to_load_p)) {
 }
 
 vector<unique_ptr<PostgresResultSlice>> SliceResult(PostgresResult &schemas, unique_ptr<PostgresResult> to_slice_ptr) {
@@ -57,7 +57,7 @@ static vector<unique_ptr<PostgresResultSlice>> SliceResultByName(PostgresResult 
 	return result;
 }
 
-string PostgresSchemaSet::GetInitializeQuery(const string &schema) {
+string PostgresSchemaSet::GetInitializeQuery(const vector<string> &schemas) {
 	string base_query = R"(
 SELECT oid, nspname
 FROM pg_namespace
@@ -65,13 +65,13 @@ ${CONDITION}
 ORDER BY oid;
 )";
 	string condition;
-	if (!schema.empty()) {
-		condition += "WHERE pg_namespace.nspname=" + KeywordHelper::WriteQuoted(schema);
+	if (schemas.size() > 0) {
+		condition += "WHERE pg_namespace.nspname IN (" + PostgresUtils::WriteLiteralsCommaSeparated(schemas) + ")";
 	}
 	return StringUtil::Replace(base_query, "${CONDITION}", condition);
 }
 
-string PostgresSchemaSet::GetInitializeQueryInformationSchema(const string &schema) {
+string PostgresSchemaSet::GetInitializeQueryInformationSchema(const vector<string> &schemas) {
 	string base_query = R"(
 SELECT schema_name
 FROM information_schema.schemata
@@ -80,15 +80,15 @@ ${CONDITION}
 ORDER BY schema_name;
 )";
 	string condition;
-	if (!schema.empty()) {
-		condition += "AND schema_name=" + KeywordHelper::WriteQuoted(schema);
+	if (schemas.size() > 0) {
+		condition += "AND schema_name IN (" + PostgresUtils::WriteLiteralsCommaSeparated(schemas) + ")";
 	}
 	return StringUtil::Replace(base_query, "${CONDITION}", condition);
 }
 
 void PostgresSchemaSet::LoadEntriesInformationSchema(ClientContext &context, PostgresTransaction &transaction) {
-	string schema_query = GetInitializeQueryInformationSchema(schema_to_load);
-	string tables_query = PostgresTableSet::GetInitializeQueryInformationSchema(schema_to_load);
+	string schema_query = GetInitializeQueryInformationSchema(schemas_to_load);
+	string tables_query = PostgresTableSet::GetInitializeQueryInformationSchema(schemas_to_load);
 	// Reading enums, composite types and indexes differs across DBs that emulate PG
 	// choice to either return those empty or have vendor specific queries for each.
 	// empty for now
@@ -125,11 +125,11 @@ void PostgresSchemaSet::LoadEntries(ClientContext &context, PostgresTransaction 
 	}
 	auto &pg_catalog = catalog.Cast<PostgresCatalog>();
 	auto pg_version = pg_catalog.GetPostgresVersion();
-	string schema_query = PostgresSchemaSet::GetInitializeQuery(schema_to_load);
-	string tables_query = PostgresTableSet::GetInitializeQuery(schema_to_load);
-	string enum_types_query = PostgresTypeSet::GetInitializeEnumsQuery(pg_version, schema_to_load);
-	string composite_types_query = PostgresTypeSet::GetInitializeCompositesQuery(schema_to_load);
-	string index_query = PostgresIndexSet::GetInitializeQuery(schema_to_load);
+	string schema_query = PostgresSchemaSet::GetInitializeQuery(schemas_to_load);
+	string tables_query = PostgresTableSet::GetInitializeQuery(schemas_to_load);
+	string enum_types_query = PostgresTypeSet::GetInitializeEnumsQuery(pg_version, schemas_to_load);
+	string composite_types_query = PostgresTypeSet::GetInitializeCompositesQuery(schemas_to_load);
+	string index_query = PostgresIndexSet::GetInitializeQuery(schemas_to_load);
 
 	auto full_query = schema_query + tables_query + enum_types_query + composite_types_query + index_query;
 

--- a/src/storage/postgres_table_set.cpp
+++ b/src/storage/postgres_table_set.cpp
@@ -20,6 +20,12 @@ PostgresTableSet::PostgresTableSet(PostgresSchemaEntry &schema, unique_ptr<Postg
 }
 
 string PostgresTableSet::GetInitializeQuery(const string &schema, const string &table) {
+	vector<string> vec;
+	vec.push_back(schema);
+	return GetInitializeQuery(vec, table);
+}
+
+string PostgresTableSet::GetInitializeQuery(const vector<string> &schemas, const string &table) {
 	string base_query = R"(
 SELECT pg_namespace.oid AS namespace_id, relname, relpages, attname,
     pg_type.typname type_name, atttypmod type_modifier, pg_attribute.attndims ndim,
@@ -48,8 +54,8 @@ WHERE relkind IN ('r', 'v', 'm', 'f', 'p') AND contype IN ('p', 'u') ${CONDITION
 ORDER BY namespace_id, relname, attnum, constraint_id;
 )";
 	string condition;
-	if (!schema.empty()) {
-		condition += "AND pg_namespace.nspname=" + KeywordHelper::WriteQuoted(schema);
+	if (schemas.size() > 0) {
+		condition += "AND pg_namespace.nspname IN (" + PostgresUtils::WriteLiteralsCommaSeparated(schemas) + ")";
 	}
 	if (!table.empty()) {
 		condition += "AND relname=" + KeywordHelper::WriteQuoted(table);
@@ -58,6 +64,12 @@ ORDER BY namespace_id, relname, attnum, constraint_id;
 }
 
 string PostgresTableSet::GetInitializeQueryInformationSchema(const string &schema, const string &table) {
+	vector<string> vec;
+	vec.push_back(schema);
+	return GetInitializeQueryInformationSchema(vec, table);
+}
+
+string PostgresTableSet::GetInitializeQueryInformationSchema(const vector<string> &schemas, const string &table) {
 	string base_query = R"(
 SELECT table_schema AS namespace_id, table_name AS relname, 0 AS relpages, column_name AS attname,
     data_type AS type_name, -1 AS type_modifier, 0 AS ndim, ordinal_position AS attnum,
@@ -69,8 +81,8 @@ WHERE table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_toast') ${CON
 ORDER BY table_schema, table_name, ordinal_position;
 )";
 	string condition;
-	if (!schema.empty()) {
-		condition += "AND table_schema=" + KeywordHelper::WriteQuoted(schema);
+	if (schemas.size() > 0) {
+		condition += "AND table_schema IN (" + PostgresUtils::WriteLiteralsCommaSeparated(schemas) + ")";
 	}
 	if (!table.empty()) {
 		condition += " AND table_name=" + KeywordHelper::WriteQuoted(table);

--- a/src/storage/postgres_type_set.cpp
+++ b/src/storage/postgres_type_set.cpp
@@ -20,7 +20,7 @@ PostgresTypeSet::PostgresTypeSet(PostgresSchemaEntry &schema, unique_ptr<Postgre
       composite_type_result(std::move(composite_type_result_p)) {
 }
 
-string PostgresTypeSet::GetInitializeEnumsQuery(PostgresVersion version, const string &schema) {
+string PostgresTypeSet::GetInitializeEnumsQuery(PostgresVersion version, const vector<string> &schemas) {
 	if (version.major_v < 8 || (version.major_v == 8 && version.minor_v < 3)) {
 		// pg_enum support has been present since v8.3 - https://www.postgresql.org/docs/8.3/catalog-pg-enum.html
 		// for older postgres versions we don't support enums instead
@@ -38,8 +38,8 @@ ${CONDITION}
 ORDER BY n.oid, enumtypid, enumsortorder;
 )";
 	string condition;
-	if (!schema.empty()) {
-		condition += "WHERE n.nspname=" + KeywordHelper::WriteQuoted(schema);
+	if (schemas.size() > 0) {
+		condition += "WHERE n.nspname IN (" + PostgresUtils::WriteLiteralsCommaSeparated(schemas) + ")";
 	}
 	return StringUtil::Replace(base_query, "${CONDITION}", condition);
 }
@@ -82,7 +82,7 @@ void PostgresTypeSet::InitializeEnums(PostgresTransaction &transaction, Postgres
 	}
 }
 
-string PostgresTypeSet::GetInitializeCompositesQuery(const string &schema) {
+string PostgresTypeSet::GetInitializeCompositesQuery(const vector<string> &schemas) {
 	string base_query = R"(
 SELECT n.oid, t.typrelid AS id, t.typname as type, pg_attribute.attname, sub_type.typname,
        sub_type_ns.nspname AS sub_type_schema
@@ -100,8 +100,8 @@ ${CONDITION}
 ORDER BY n.oid, t.oid, attrelid, attnum;
 )";
 	string condition;
-	if (!schema.empty()) {
-		condition += "AND n.nspname=" + KeywordHelper::WriteQuoted(schema);
+	if (schemas.size() > 0) {
+		condition += "AND n.nspname IN (" + PostgresUtils::WriteLiteralsCommaSeparated(schemas) + ")";
 	}
 	return StringUtil::Replace(base_query, "${CONDITION}", condition);
 }

--- a/test/sql/storage/attach_schema_param_list.test
+++ b/test/sql/storage/attach_schema_param_list.test
@@ -1,0 +1,106 @@
+# name: test/sql/storage/attach_schema_param_list.test
+# description: Test attaching multiple specific schemas
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+# prepare schemas
+
+statement ok
+CALL postgres_execute('s', 'DROP SCHEMA IF EXISTS duckdb_test_sch1 CASCADE')
+
+statement ok
+CALL postgres_execute('s', 'DROP SCHEMA IF EXISTS duckdb_test_sch2 CASCADE')
+
+statement ok
+CALL postgres_execute('s', 'DROP SCHEMA IF EXISTS duckdb_test_sch3 CASCADE')
+
+statement ok
+CALL postgres_execute('s', 'CREATE SCHEMA duckdb_test_sch1')
+
+statement ok
+CALL postgres_execute('s', 'CREATE SCHEMA duckdb_test_sch2')
+
+statement ok
+CALL postgres_execute('s', 'CREATE SCHEMA duckdb_test_sch3')
+
+statement ok
+CALL postgres_execute('s', 'CREATE TABLE duckdb_test_sch1.tab1(col1 INT)')
+
+statement ok
+CALL postgres_execute('s', 'INSERT INTO duckdb_test_sch1.tab1 VALUES(42)')
+
+statement ok
+CALL postgres_execute('s', 'CREATE TABLE duckdb_test_sch2.tab2(col2 INT)')
+
+statement ok
+CALL postgres_execute('s', 'INSERT INTO duckdb_test_sch2.tab2 VALUES(43)')
+
+statement ok
+CALL postgres_execute('s', 'CREATE TABLE duckdb_test_sch3.tab3(col3 INT)')
+
+statement ok
+CALL postgres_execute('s', 'INSERT INTO duckdb_test_sch3.tab3 VALUES(44)')
+
+statement ok
+DETACH s
+
+statement error
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, SCHEMA NULL)
+----
+Binder Error
+
+statement error
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, SCHEMA 42)
+----
+Binder Error
+
+statement error
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, SCHEMA [41, 42])
+----
+Binder Error
+
+statement error
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, SCHEMA ['foo', NULL])
+----
+Binder Error
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, SCHEMA ['duckdb_test_sch1', 'duckdb_test_sch2'])
+
+query I
+FROM s.duckdb_test_sch1.tab1
+----
+42
+
+query I
+FROM s.duckdb_test_sch2.tab2
+----
+43
+
+statement error
+FROM s.duckdb_test_sch3.tab3
+----
+Catalog Error: Table with name "duckdb_test_sch3.tab3" does not exist because schema "duckdb_test_sch3" does not exist.
+
+# cleanup
+
+statement ok
+CALL postgres_execute('s', 'DROP SCHEMA duckdb_test_sch1 CASCADE')
+
+statement ok
+CALL postgres_execute('s', 'DROP SCHEMA duckdb_test_sch2 CASCADE')
+
+statement ok
+CALL postgres_execute('s', 'DROP SCHEMA duckdb_test_sch3 CASCADE')
+
+statement ok
+USE memory
+
+statement ok
+DETACH s


### PR DESCRIPTION
This is a backport of the PR #510 to `v1.5-variegata` stable branch.

This PR extends the `SCHEMA` option for `ATTACH` allowing it additionally to take a list of schemas:

```sql
ATTACH '...' AS p (TYPE POSTGRES, SCHEMA ['s1', 's2', 's3'])
```

Testing: new test added that covers visibility for multiple schemas.

Closes: #498