### PR TITLE
fix: detect Postgres table catalog staleness

### DIFF
--- a/.github/workflows/IntegrationTests.yml
+++ b/.github/workflows/IntegrationTests.yml
@@ -345,6 +345,7 @@ jobs:
         PGPASSWORD: postgres
         PGSSLMODE: require
         POSTGRES_TEST_DATABASE_AVAILABLE: 1
+        SANITIZER_BUILD: 1
         LOCAL_EXTENSION_REPO: 'build/relassert/repository'
       run: |
         source ./create-postgres-tables.sh

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ D SELECT * FROM postgres_db.uuids;
 
 For more information on how to use the connector, refer to the [Postgres documentation on the website](https://duckdb.org/docs/extensions/postgres).
 
+### Connection Pooling
+
+By default, the extension opens a new connection whenever none are idle. Behind a transaction-mode pooler (e.g. PgBouncer `pool_mode=transaction`), this can exceed the pooler's own pool size under load and hang. If that applies to you, cap and wait instead:
+
+```sql
+SET pg_pool_acquire_mode = 'wait';
+SET pg_pool_max_connections = 16;        -- ~80-90% of your pooler's pool size
+
+ATTACH 'host=pgbouncer-host port=6432 dbname=mydb' AS postgres_db (TYPE postgres);
+```
+
+Note that `SET` statements are global and only apply pre-`ATTACH`. To change pooling on an already-attached database, use `postgres_configure_pool(catalog_name=...)` instead. Leave `force` mode if you connect directly to Postgres or through a session-mode pooler.
+
 ### AWS RDS IAM Authentication
 
 The extension supports AWS RDS IAM-based authentication, which allows you to connect to RDS/Aurora PostgreSQL instances using IAM database authentication instead of static passwords. This feature automatically generates temporary authentication tokens using the AWS SDK.

--- a/src/include/postgres_result.hpp
+++ b/src/include/postgres_result.hpp
@@ -48,6 +48,10 @@ public:
 		D_ASSERT(res);
 		return PQntuples(res);
 	}
+	idx_t ColumnCount() {
+		D_ASSERT(res);
+		return PQnfields(res);
+	}
 	idx_t AffectedRows() {
 		auto affected = PQcmdTuples(res);
 		if (!affected) {

--- a/src/include/postgres_utils.hpp
+++ b/src/include/postgres_utils.hpp
@@ -63,6 +63,8 @@ public:
 	static PGconn *PGConnect(const string &dsn, const string &attach_path);
 
 	static bool UseInformationSchemaIntrospection(optional_ptr<ClientContext> context);
+	static bool StalenessQueryEnabled(ClientContext &context);
+	static string GetCustomStalenessQuery(ClientContext &context);
 	static string DataTypeToTypeName(const string &data_type);
 	static LogicalType ToPostgresType(const LogicalType &input);
 	static LogicalType TypeToLogicalType(optional_ptr<PostgresTransaction> transaction,

--- a/src/include/storage/postgres_catalog_set.hpp
+++ b/src/include/storage/postgres_catalog_set.hpp
@@ -43,12 +43,17 @@ protected:
 		return false;
 	}
 	//! Empty (default) means staleness is never checked once loaded
-	virtual string GetStalenessQuery() const {
+	virtual string GetStalenessQuery(ClientContext &context) const {
 		return string();
 	}
 	void TryLoadEntries(ClientContext &context, PostgresTransaction &transaction);
-	void RefreshStalenessSignature(PostgresTransaction &transaction);
+	void RefreshStalenessSignature(PostgresTransaction &transaction, bool use_transaction_connection);
 
+private:
+	//! Runs LoadEntries + RefreshStalenessSignature, must be called with load_lock held
+	void LoadEntriesLocked(ClientContext &context, PostgresTransaction &transaction);
+
+protected:
 public:
 	void PromoteStalenessSignature(string signature);
 

--- a/src/include/storage/postgres_catalog_set.hpp
+++ b/src/include/storage/postgres_catalog_set.hpp
@@ -42,7 +42,15 @@ protected:
 	virtual bool HasInternalDependencies() const {
 		return false;
 	}
+	//! Empty (default) means staleness is never checked once loaded
+	virtual string GetStalenessQuery() const {
+		return string();
+	}
 	void TryLoadEntries(ClientContext &context, PostgresTransaction &transaction);
+	void RefreshStalenessSignature(PostgresTransaction &transaction);
+
+public:
+	void PromoteStalenessSignature(string signature);
 
 protected:
 	Catalog &catalog;
@@ -54,6 +62,7 @@ private:
 	case_insensitive_map_t<string> entry_map;
 	atomic<bool> is_loaded;
 	atomic<thread_id> loading_thread;
+	string staleness_signature;
 };
 
 class PostgresInSchemaSet : public PostgresCatalogSet {

--- a/src/include/storage/postgres_table_set.hpp
+++ b/src/include/storage/postgres_table_set.hpp
@@ -42,7 +42,7 @@ protected:
 	bool SupportReload() const override {
 		return true;
 	}
-	string GetStalenessQuery() const override;
+	string GetStalenessQuery(ClientContext &context) const override;
 
 	void AlterTable(ClientContext &context, PostgresTransaction &transaction, RenameTableInfo &info);
 	void AlterTable(ClientContext &context, PostgresTransaction &transaction, RenameColumnInfo &info);

--- a/src/include/storage/postgres_table_set.hpp
+++ b/src/include/storage/postgres_table_set.hpp
@@ -42,6 +42,7 @@ protected:
 	bool SupportReload() const override {
 		return true;
 	}
+	string GetStalenessQuery() const override;
 
 	void AlterTable(ClientContext &context, PostgresTransaction &transaction, RenameTableInfo &info);
 	void AlterTable(ClientContext &context, PostgresTransaction &transaction, RenameColumnInfo &info);

--- a/src/include/storage/postgres_transaction.hpp
+++ b/src/include/storage/postgres_transaction.hpp
@@ -14,6 +14,7 @@
 
 namespace duckdb {
 class PostgresCatalog;
+class PostgresCatalogSet;
 class PostgresSchemaEntry;
 class PostgresTableEntry;
 
@@ -43,6 +44,11 @@ public:
 
 	string GetTemporarySchema();
 
+	PostgresTransactionState GetTransactionState() const {
+		return transaction_state;
+	}
+	void StageStalenessSignature(PostgresCatalogSet &catalog_set, string signature);
+
 private:
 	PostgresPoolConnection connection;
 	PostgresTransactionState transaction_state;
@@ -51,6 +57,8 @@ private:
 	string temporary_schema;
 	mutex referenced_entries_lock;
 	reference_map_t<CatalogEntry, shared_ptr<CatalogEntry>> referenced_entries;
+	mutex pending_signatures_lock;
+	vector<pair<reference<PostgresCatalogSet>, string>> pending_signatures;
 
 private:
 	//! Retrieves the connection **without** starting a transaction if none is active

--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -215,6 +215,18 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    "Use SQL-standard information_schema views for ATTACH-time schema discovery instead of pg_catalog."
 	    "For compatibility with pg protocol compatible databases like spanner, cockroach, redshift, ...",
 	    LogicalType::BOOLEAN, Value::BOOLEAN(false), PostgresClearCacheFunction::ClearCacheOnSetting);
+	config.AddExtensionOption(
+	    "pg_staleness_query_enabled",
+	    "Whether or not the table catalog cache checks Postgres for external DDL changes before serving a "
+	    "cache hit. Defaults to the opposite of pg_use_information_schema_introspection when not explicitly set "
+	    "(off for pg protocol compatible databases that may not support the underlying query, on for Postgres).",
+	    LogicalType::BOOLEAN, Value(), PostgresClearCacheFunction::ClearCacheOnSetting);
+	config.AddExtensionOption(
+	    "pg_staleness_query",
+	    "Custom query used in place of the default table staleness query when pg_staleness_query_enabled "
+	    "resolves to true. Must contain a ${SCHEMA} placeholder and return at least 3 columns "
+	    "(identity, name, revision marker). Empty (default) uses the built-in pg_class/xmin query.",
+	    LogicalType::VARCHAR, Value(), PostgresClearCacheFunction::ClearCacheOnSetting);
 	config.AddExtensionOption("pg_statement_timeout_millis",
 	                          "Postgres statement timeout in milliseconds to set on scan connections",
 	                          LogicalType::UINTEGER, Value());

--- a/src/postgres_utils.cpp
+++ b/src/postgres_utils.cpp
@@ -89,6 +89,22 @@ bool PostgresUtils::UseInformationSchemaIntrospection(optional_ptr<ClientContext
 	return false;
 }
 
+bool PostgresUtils::StalenessQueryEnabled(ClientContext &context) {
+	Value value;
+	if (context.TryGetCurrentSetting("pg_staleness_query_enabled", value) && !value.IsNull()) {
+		return BooleanValue::Get(value);
+	}
+	return !UseInformationSchemaIntrospection(&context);
+}
+
+string PostgresUtils::GetCustomStalenessQuery(ClientContext &context) {
+	Value value;
+	if (context.TryGetCurrentSetting("pg_staleness_query", value) && !value.IsNull()) {
+		return StringValue::Get(value);
+	}
+	return string();
+}
+
 string PostgresUtils::DataTypeToTypeName(const string &data_type) {
 	// Map SQL-standard information_schema.columns.data_type values to the
 	// pg_type.typname

--- a/src/storage/postgres_catalog_set.cpp
+++ b/src/storage/postgres_catalog_set.cpp
@@ -1,5 +1,6 @@
 #include "storage/postgres_catalog_set.hpp"
 
+#include "storage/postgres_catalog.hpp"
 #include "storage/postgres_transaction.hpp"
 #include "duckdb/parser/parsed_data/drop_info.hpp"
 #include "storage/postgres_schema_entry.hpp"
@@ -44,6 +45,11 @@ optional_ptr<CatalogEntry> PostgresCatalogSet::GetEntry(ClientContext &context, 
 }
 
 static string ComputeStalenessSignature(PostgresResult &result) {
+	if (result.ColumnCount() < 3) {
+		throw InvalidInputException(
+		    "pg_staleness_query must return at least 3 columns (identity, name, revision marker), got %llu",
+		    result.ColumnCount());
+	}
 	string signature;
 	auto rows = result.Count();
 	for (idx_t row = 0; row < rows; row++) {
@@ -57,16 +63,26 @@ static string ComputeStalenessSignature(PostgresResult &result) {
 	return signature;
 }
 
-void PostgresCatalogSet::RefreshStalenessSignature(PostgresTransaction &transaction) {
-	auto staleness_query = GetStalenessQuery();
+//! Runs the staleness query on a short-lived pooled connection, not the caller's own.
+//! Avoids pinning the caller's connection (and, under PgBouncer transaction-mode pooling,
+//! a backend slot) for the round-trip.
+static unique_ptr<PostgresResult> RunStalenessQuery(Catalog &catalog, ClientContext &context,
+                                                    const string &staleness_query) {
+	auto connection = catalog.Cast<PostgresCatalog>().GetConnectionPool().GetConnection();
+	return connection.GetConnection().Query(context, staleness_query);
+}
+
+void PostgresCatalogSet::RefreshStalenessSignature(PostgresTransaction &transaction, bool use_transaction_connection) {
+	auto &context = *transaction.GetContext();
+	auto staleness_query = GetStalenessQuery(context);
 	if (staleness_query.empty()) {
 		return;
 	}
-	auto result = transaction.Query(staleness_query);
+	auto result = use_transaction_connection ? transaction.Query(staleness_query)
+	                                         : RunStalenessQuery(catalog, context, staleness_query);
 	auto signature = ComputeStalenessSignature(*result);
 	if (transaction.GetTransactionState() == PostgresTransactionState::TRANSACTION_STARTED) {
-		// an explicit transaction is still open - this signature is only valid if/when it commits,
-		// since Postgres xmin can revert on rollback and spuriously match a pre-transaction signature
+		// transaction still open - only valid on commit, since xmin reverts on rollback
 		transaction.StageStalenessSignature(*this, std::move(signature));
 		return;
 	}
@@ -74,7 +90,22 @@ void PostgresCatalogSet::RefreshStalenessSignature(PostgresTransaction &transact
 }
 
 void PostgresCatalogSet::PromoteStalenessSignature(string signature) {
+	// called from Commit(), possibly a different thread than the one that staged it
+	lock_guard<mutex> lock(load_lock);
 	staleness_signature = std::move(signature);
+}
+
+void PostgresCatalogSet::LoadEntriesLocked(ClientContext &context, PostgresTransaction &transaction) {
+	loading_thread = ThreadUtil::GetThreadId();
+	try {
+		LoadEntries(context, transaction);
+	} catch (...) {
+		loading_thread = thread_id();
+		throw;
+	}
+	RefreshStalenessSignature(transaction, /*use_transaction_connection=*/false);
+	is_loaded = true;
+	loading_thread = thread_id();
 }
 
 void PostgresCatalogSet::TryLoadEntries(ClientContext &context, PostgresTransaction &transaction) {
@@ -83,29 +114,34 @@ void PostgresCatalogSet::TryLoadEntries(ClientContext &context, PostgresTransact
 			return;
 		}
 	}
-	lock_guard<mutex> lock(load_lock);
 	if (is_loaded) {
-		auto staleness_query = GetStalenessQuery();
+		auto staleness_query = GetStalenessQuery(context);
 		if (staleness_query.empty()) {
 			return;
 		}
-		auto result = transaction.Query(staleness_query);
+		// runs outside load_lock - avoids blocking other threads on this thread's network round-trip
+		auto result = RunStalenessQuery(catalog, context, staleness_query);
 		auto signature = ComputeStalenessSignature(*result);
-		if (signature == staleness_signature) {
-			return;
+
+		lock_guard<mutex> lock(load_lock);
+		if (is_loaded) {
+			if (signature == staleness_signature) {
+				return;
+			}
+			ClearEntries();
 		}
-		ClearEntries();
+		// else: someone else cleared/reloaded while we were checking - fall through to the
+		// reload below, still holding load_lock.
+		LoadEntriesLocked(context, transaction);
+		return;
 	}
-	loading_thread = ThreadUtil::GetThreadId();
-	try {
-		LoadEntries(context, transaction);
-	} catch (...) {
-		loading_thread = thread_id();
-		throw;
+
+	lock_guard<mutex> lock(load_lock);
+	if (is_loaded) {
+		// someone else already loaded while we were waiting for the lock.
+		return;
 	}
-	RefreshStalenessSignature(transaction);
-	is_loaded = true;
-	loading_thread = thread_id();
+	LoadEntriesLocked(context, transaction);
 }
 
 optional_ptr<CatalogEntry> PostgresCatalogSet::ReloadEntry(PostgresTransaction &transaction, const string &name) {
@@ -132,7 +168,7 @@ void PostgresCatalogSet::DropEntry(PostgresTransaction &transaction, DropInfo &i
 		lock_guard<mutex> l(entry_lock);
 		entries.erase(info.GetQualifiedName().Name().GetIdentifierName());
 	}
-	RefreshStalenessSignature(transaction);
+	RefreshStalenessSignature(transaction, /*use_transaction_connection=*/true);
 }
 
 void PostgresCatalogSet::Scan(ClientContext &context, PostgresTransaction &transaction,

--- a/src/storage/postgres_catalog_set.cpp
+++ b/src/storage/postgres_catalog_set.cpp
@@ -43,6 +43,40 @@ optional_ptr<CatalogEntry> PostgresCatalogSet::GetEntry(ClientContext &context, 
 	return nullptr;
 }
 
+static string ComputeStalenessSignature(PostgresResult &result) {
+	string signature;
+	auto rows = result.Count();
+	for (idx_t row = 0; row < rows; row++) {
+		signature += result.GetString(row, 0);
+		signature += '\0';
+		signature += result.GetString(row, 1);
+		signature += '\0';
+		signature += result.GetString(row, 2);
+		signature += '\x01';
+	}
+	return signature;
+}
+
+void PostgresCatalogSet::RefreshStalenessSignature(PostgresTransaction &transaction) {
+	auto staleness_query = GetStalenessQuery();
+	if (staleness_query.empty()) {
+		return;
+	}
+	auto result = transaction.Query(staleness_query);
+	auto signature = ComputeStalenessSignature(*result);
+	if (transaction.GetTransactionState() == PostgresTransactionState::TRANSACTION_STARTED) {
+		// an explicit transaction is still open - this signature is only valid if/when it commits,
+		// since Postgres xmin can revert on rollback and spuriously match a pre-transaction signature
+		transaction.StageStalenessSignature(*this, std::move(signature));
+		return;
+	}
+	staleness_signature = std::move(signature);
+}
+
+void PostgresCatalogSet::PromoteStalenessSignature(string signature) {
+	staleness_signature = std::move(signature);
+}
+
 void PostgresCatalogSet::TryLoadEntries(ClientContext &context, PostgresTransaction &transaction) {
 	if (HasInternalDependencies()) {
 		if (is_loaded || loading_thread == ThreadUtil::GetThreadId()) {
@@ -51,7 +85,16 @@ void PostgresCatalogSet::TryLoadEntries(ClientContext &context, PostgresTransact
 	}
 	lock_guard<mutex> lock(load_lock);
 	if (is_loaded) {
-		return;
+		auto staleness_query = GetStalenessQuery();
+		if (staleness_query.empty()) {
+			return;
+		}
+		auto result = transaction.Query(staleness_query);
+		auto signature = ComputeStalenessSignature(*result);
+		if (signature == staleness_signature) {
+			return;
+		}
+		ClearEntries();
 	}
 	loading_thread = ThreadUtil::GetThreadId();
 	try {
@@ -60,6 +103,7 @@ void PostgresCatalogSet::TryLoadEntries(ClientContext &context, PostgresTransact
 		loading_thread = thread_id();
 		throw;
 	}
+	RefreshStalenessSignature(transaction);
 	is_loaded = true;
 	loading_thread = thread_id();
 }
@@ -84,8 +128,11 @@ void PostgresCatalogSet::DropEntry(PostgresTransaction &transaction, DropInfo &i
 	transaction.Query(drop_query);
 
 	// erase the entry from the catalog set
-	lock_guard<mutex> l(entry_lock);
-	entries.erase(info.GetQualifiedName().Name().GetIdentifierName());
+	{
+		lock_guard<mutex> l(entry_lock);
+		entries.erase(info.GetQualifiedName().Name().GetIdentifierName());
+	}
+	RefreshStalenessSignature(transaction);
 }
 
 void PostgresCatalogSet::Scan(ClientContext &context, PostgresTransaction &transaction,

--- a/src/storage/postgres_table_set.cpp
+++ b/src/storage/postgres_table_set.cpp
@@ -212,7 +212,18 @@ void PostgresTableSet::LoadEntries(ClientContext &context, PostgresTransaction &
 	}
 }
 
-string PostgresTableSet::GetStalenessQuery() const {
+string PostgresTableSet::GetStalenessQuery(ClientContext &context) const {
+	if (!PostgresUtils::StalenessQueryEnabled(context)) {
+		return string();
+	}
+	auto custom_query = PostgresUtils::GetCustomStalenessQuery(context);
+	if (!custom_query.empty()) {
+		if (custom_query.find("${SCHEMA}") == string::npos) {
+			throw InvalidInputException("pg_staleness_query must contain a ${SCHEMA} placeholder");
+		}
+		return StringUtil::Replace(custom_query, "${SCHEMA}",
+		                           PostgresUtils::WriteLiteral(schema.name.GetIdentifierName()));
+	}
 	string base_query = R"(
 SELECT pg_class.oid, relname, pg_class.xmin
 FROM pg_class
@@ -274,7 +285,7 @@ optional_ptr<CatalogEntry> PostgresTableSet::ReloadEntry(PostgresTransaction &tr
 	}
 	auto table_entry = make_shared_ptr<PostgresTableEntry>(catalog, schema, *table_info);
 	auto result = CreateEntry(transaction, std::move(table_entry));
-	RefreshStalenessSignature(transaction);
+	RefreshStalenessSignature(transaction, /*use_transaction_connection=*/false);
 	return result;
 }
 
@@ -398,7 +409,7 @@ optional_ptr<CatalogEntry> PostgresTableSet::CreateTable(PostgresTransaction &tr
 	transaction.Query(create_sql);
 	auto tbl_entry = make_shared_ptr<PostgresTableEntry>(catalog, schema, info.Base());
 	auto result = CreateEntry(transaction, std::move(tbl_entry));
-	RefreshStalenessSignature(transaction);
+	RefreshStalenessSignature(transaction, /*use_transaction_connection=*/true);
 	return result;
 }
 

--- a/src/storage/postgres_table_set.cpp
+++ b/src/storage/postgres_table_set.cpp
@@ -212,6 +212,17 @@ void PostgresTableSet::LoadEntries(ClientContext &context, PostgresTransaction &
 	}
 }
 
+string PostgresTableSet::GetStalenessQuery() const {
+	string base_query = R"(
+SELECT pg_class.oid, relname, pg_class.xmin
+FROM pg_class
+JOIN pg_namespace ON relnamespace = pg_namespace.oid
+WHERE relkind IN ('r', 'v', 'm', 'f', 'p') AND pg_namespace.nspname = ${SCHEMA}
+ORDER BY pg_class.oid;
+)";
+	return StringUtil::Replace(base_query, "${SCHEMA}", PostgresUtils::WriteLiteral(schema.name.GetIdentifierName()));
+}
+
 unique_ptr<PostgresTableInfo> PostgresTableSet::GetTableInfo(PostgresTransaction &transaction,
                                                              PostgresSchemaEntry &schema, const string &table_name) {
 	auto query = PostgresUtils::UseInformationSchemaIntrospection(transaction.GetContext())
@@ -262,7 +273,9 @@ optional_ptr<CatalogEntry> PostgresTableSet::ReloadEntry(PostgresTransaction &tr
 		return nullptr;
 	}
 	auto table_entry = make_shared_ptr<PostgresTableEntry>(catalog, schema, *table_info);
-	return CreateEntry(transaction, std::move(table_entry));
+	auto result = CreateEntry(transaction, std::move(table_entry));
+	RefreshStalenessSignature(transaction);
+	return result;
 }
 
 // FIXME - this is almost entirely copied from TableCatalogEntry::ColumnsToSQL - should be unified
@@ -384,7 +397,9 @@ optional_ptr<CatalogEntry> PostgresTableSet::CreateTable(PostgresTransaction &tr
 	auto create_sql = GetPostgresCreateTable(info.Base());
 	transaction.Query(create_sql);
 	auto tbl_entry = make_shared_ptr<PostgresTableEntry>(catalog, schema, info.Base());
-	return CreateEntry(transaction, std::move(tbl_entry));
+	auto result = CreateEntry(transaction, std::move(tbl_entry));
+	RefreshStalenessSignature(transaction);
+	return result;
 }
 
 string PostgresTableSet::GetAlterTablePrefix(const string &name, optional_ptr<CatalogEntry> entry) {

--- a/src/storage/postgres_transaction.cpp
+++ b/src/storage/postgres_transaction.cpp
@@ -1,5 +1,6 @@
 #include "storage/postgres_transaction.hpp"
 #include "storage/postgres_catalog.hpp"
+#include "storage/postgres_catalog_set.hpp"
 #include "duckdb/parser/parsed_data/create_view_info.hpp"
 #include "duckdb/catalog/catalog_entry/index_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
@@ -30,12 +31,22 @@ void PostgresTransaction::Commit() {
 		transaction_state = PostgresTransactionState::TRANSACTION_FINISHED;
 		GetConnectionRaw().Execute(GetContext(), "COMMIT");
 	}
+	vector<pair<reference<PostgresCatalogSet>, string>> to_promote;
+	{
+		lock_guard<mutex> l(pending_signatures_lock);
+		to_promote = std::move(pending_signatures);
+	}
+	for (auto &entry : to_promote) {
+		entry.first.get().PromoteStalenessSignature(std::move(entry.second));
+	}
 }
 void PostgresTransaction::Rollback() {
 	if (transaction_state == PostgresTransactionState::TRANSACTION_STARTED) {
 		transaction_state = PostgresTransactionState::TRANSACTION_FINISHED;
 		GetConnectionRaw().Execute(GetContext(), "ROLLBACK");
 	}
+	lock_guard<mutex> l(pending_signatures_lock);
+	pending_signatures.clear();
 }
 
 string PostgresTransaction::GetBeginTransactionQuery() {
@@ -129,6 +140,11 @@ optional_ptr<CatalogEntry> PostgresTransaction::ReferenceEntry(shared_ptr<Catalo
 	lock_guard<mutex> l(referenced_entries_lock);
 	referenced_entries.emplace(ref, entry);
 	return ref;
+}
+
+void PostgresTransaction::StageStalenessSignature(PostgresCatalogSet &catalog_set, string signature) {
+	lock_guard<mutex> l(pending_signatures_lock);
+	pending_signatures.emplace_back(catalog_set, std::move(signature));
 }
 
 string PostgresTransaction::GetTemporarySchema() {

--- a/test/sql/storage/attach_connection_pool.test_slow
+++ b/test/sql/storage/attach_connection_pool.test_slow
@@ -120,11 +120,12 @@ s	SELECT 42
 statement ok
 DROP TABLE duckdb_connection_pool_test1
 
+# 2, not 1: DROP TABLE's cache-hit staleness check uses its own pooled connection
 query II
 SELECT catalog_name, available_connections
 FROM postgres_configure_pool(catalog_name='s')
 ----
-s	1
+s	2
 
 statement ok
 USE memory

--- a/test/sql/storage/catalog_cache_external_ddl_visibility.test
+++ b/test/sql/storage/catalog_cache_external_ddl_visibility.test
@@ -1,0 +1,52 @@
+# name: test/sql/storage/catalog_cache_external_ddl_visibility.test
+# description: DDL from a separate ClientContext must become visible without an explicit pg_clear_cache() call
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+# con1: prime an empty-schema cache
+statement ok con1
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok con1
+USE s
+
+statement ok con1
+DROP TABLE IF EXISTS ext_ddl_visibility_tbl
+
+query I con1
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 's' AND table_name = 'ext_ddl_visibility_tbl'
+----
+0
+
+# con2: a genuinely separate ClientContext, attaching the same physical database
+statement ok con2
+ATTACH 'dbname=postgresscanner' AS s2 (TYPE POSTGRES)
+
+statement ok con2
+USE s2
+
+statement ok con2
+CREATE TABLE ext_ddl_visibility_tbl AS SELECT 1 AS x
+
+# con1: re-query without any pg_clear_cache() call from either connection
+query I con1
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 's' AND table_name = 'ext_ddl_visibility_tbl'
+----
+1
+
+query I con1
+SELECT x FROM ext_ddl_visibility_tbl
+----
+1
+
+statement ok con1
+DROP TABLE ext_ddl_visibility_tbl
+
+statement ok con2
+USE memory
+
+statement ok con2
+DETACH s2

--- a/test/sql/storage/catalog_cache_identity_swap_detected.test
+++ b/test/sql/storage/catalog_cache_identity_swap_detected.test
@@ -1,0 +1,58 @@
+# name: test/sql/storage/catalog_cache_identity_swap_detected.test
+# description: drop+create in the same schema that leaves row count unchanged must still be detected as stale (adversarial case that rules out a pure cardinality or xmin-aggregation staleness signal)
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok con1
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok con1
+USE s
+
+statement ok con1
+DROP TABLE IF EXISTS identity_swap_foo
+
+statement ok con1
+DROP TABLE IF EXISTS identity_swap_bar
+
+statement ok con1
+CREATE TABLE identity_swap_foo AS SELECT 1 AS x
+
+# prime the cache with foo present
+query I con1
+SELECT table_name FROM duckdb_tables() WHERE table_name LIKE 'identity_swap_%' ORDER BY table_name
+----
+identity_swap_foo
+
+statement ok con2
+ATTACH 'dbname=postgresscanner' AS s2 (TYPE POSTGRES)
+
+statement ok con2
+USE s2
+
+# net pg_class row count for this schema is unchanged: one dropped, one created
+statement ok con2
+DROP TABLE identity_swap_foo
+
+statement ok con2
+CREATE TABLE identity_swap_bar AS SELECT 2 AS y
+
+# con1 must see bar and must NOT still see foo, despite unchanged cardinality
+# (filtered to database_name = 's' - con2's own s2 attach of the same physical
+# DB would otherwise also surface identity_swap_bar a second time)
+query I con1
+SELECT table_name FROM duckdb_tables() WHERE database_name = 's' AND table_name LIKE 'identity_swap_%' ORDER BY table_name
+----
+identity_swap_bar
+
+statement ok con1
+DROP TABLE identity_swap_bar
+
+statement ok con2
+USE memory
+
+statement ok con2
+DETACH s2

--- a/test/sql/storage/catalog_cache_staged_signature_cross_connection.test
+++ b/test/sql/storage/catalog_cache_staged_signature_cross_connection.test
@@ -1,0 +1,83 @@
+# name: test/sql/storage/catalog_cache_staged_signature_cross_connection.test
+# description: a pending staleness signature staged by one connection's open explicit transaction must not be promoted or discarded by a concurrent, unrelated autocommit write from a different connection
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok con1
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok con1
+USE s
+
+statement ok con1
+DROP TABLE IF EXISTS staged_sig_test
+
+statement ok con1
+CREATE TABLE staged_sig_test(i INTEGER)
+
+statement ok con1
+INSERT INTO s.staged_sig_test VALUES (42)
+
+# prime con1's cache
+query I con1
+SELECT column_name FROM duckdb_columns() WHERE table_name = 'staged_sig_test' ORDER BY column_name
+----
+i
+
+statement ok con2
+ATTACH 'dbname=postgresscanner' AS s2 (TYPE POSTGRES)
+
+statement ok con2
+USE s2
+
+# con1 opens an explicit transaction, alters the table, and forces a reload that stages a
+# pending signature (not yet committed to con1's PostgresTableSet::staleness_signature)
+statement ok con1
+BEGIN
+
+statement ok con1
+ALTER TABLE s.staged_sig_test ADD COLUMN j INTEGER
+
+query I con1
+SELECT j FROM s.staged_sig_test
+----
+NULL
+
+# concurrently, con2 (autocommit, unrelated connection) writes a *different* table in the
+# same schema and commits - this must not promote or clobber con1's still-pending signature
+statement ok con2
+DROP TABLE IF EXISTS staged_sig_unrelated
+
+statement ok con2
+CREATE TABLE staged_sig_unrelated(x INTEGER)
+
+# con1 rolls back its own transaction - its pending signature (with column j) must be discarded,
+# not promoted, regardless of what con2 did concurrently
+statement ok con1
+ROLLBACK
+
+statement error con1
+SELECT j FROM s.staged_sig_test
+----
+not found
+
+# con1's cache must still correctly see con2's committed, unrelated change on the next access
+query I con1
+SELECT table_name FROM duckdb_tables() WHERE database_name = 's' AND table_name = 'staged_sig_unrelated'
+----
+staged_sig_unrelated
+
+statement ok con1
+DROP TABLE staged_sig_test
+
+statement ok con1
+DROP TABLE staged_sig_unrelated
+
+statement ok con2
+USE memory
+
+statement ok con2
+DETACH s2

--- a/test/sql/storage/catalog_cache_staleness_wire_compat_gating.test
+++ b/test/sql/storage/catalog_cache_staleness_wire_compat_gating.test
@@ -1,0 +1,247 @@
+# name: test/sql/storage/catalog_cache_staleness_wire_compat_gating.test
+# description: pg_staleness_query_enabled gates automatic staleness detection, default tied to pg_use_information_schema_introspection
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+# ---------------------------------------------------------------------------
+# Default-on for real Postgres (unchanged behavior)
+# ---------------------------------------------------------------------------
+statement ok con1
+ATTACH 'dbname=postgresscanner' AS wc1 (TYPE POSTGRES)
+
+statement ok con1
+DROP TABLE IF EXISTS wc1.public.staleness_gating_tbl1
+
+query I con1
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'wc1' AND table_name = 'staleness_gating_tbl1'
+----
+0
+
+statement ok con2
+ATTACH 'dbname=postgresscanner' AS wc1b (TYPE POSTGRES)
+
+statement ok con2
+CREATE TABLE wc1b.public.staleness_gating_tbl1 AS SELECT 1 AS x
+
+query I con1
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'wc1' AND table_name = 'staleness_gating_tbl1'
+----
+1
+
+statement ok con1
+DROP TABLE wc1.public.staleness_gating_tbl1
+
+statement ok con2
+DETACH wc1b
+
+statement ok con1
+DETACH wc1
+
+# ---------------------------------------------------------------------------
+# Default-off when compat mode is signaled
+# ---------------------------------------------------------------------------
+statement ok con1
+SET pg_use_information_schema_introspection=true
+
+statement ok con1
+ATTACH 'dbname=postgresscanner' AS wc2 (TYPE POSTGRES)
+
+statement ok con1
+DROP TABLE IF EXISTS wc2.public.staleness_gating_tbl2
+
+query I con1
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'wc2' AND table_name = 'staleness_gating_tbl2'
+----
+0
+
+statement ok con2
+ATTACH 'dbname=postgresscanner' AS wc2b (TYPE POSTGRES)
+
+statement ok con2
+CREATE TABLE wc2b.public.staleness_gating_tbl2 AS SELECT 1 AS x
+
+query I con1
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'wc2' AND table_name = 'staleness_gating_tbl2'
+----
+0
+
+statement ok con2
+DROP TABLE wc2b.public.staleness_gating_tbl2
+
+statement ok con2
+DETACH wc2b
+
+statement ok con1
+RESET pg_use_information_schema_introspection
+
+statement ok con1
+DETACH wc2
+
+# ---------------------------------------------------------------------------
+# Explicit override wins, on-direction
+# ---------------------------------------------------------------------------
+statement ok con1
+SET pg_use_information_schema_introspection=true
+
+statement ok con1
+SET pg_staleness_query_enabled=true
+
+statement ok con1
+ATTACH 'dbname=postgresscanner' AS wc3 (TYPE POSTGRES)
+
+statement ok con1
+DROP TABLE IF EXISTS wc3.public.staleness_gating_tbl3
+
+query I con1
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'wc3' AND table_name = 'staleness_gating_tbl3'
+----
+0
+
+statement ok con2
+ATTACH 'dbname=postgresscanner' AS wc3b (TYPE POSTGRES)
+
+statement ok con2
+CREATE TABLE wc3b.public.staleness_gating_tbl3 AS SELECT 1 AS x
+
+query I con1
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'wc3' AND table_name = 'staleness_gating_tbl3'
+----
+1
+
+statement ok con1
+DROP TABLE wc3.public.staleness_gating_tbl3
+
+statement ok con2
+DETACH wc3b
+
+statement ok con1
+RESET pg_use_information_schema_introspection
+
+statement ok con1
+RESET pg_staleness_query_enabled
+
+statement ok con1
+DETACH wc3
+
+# ---------------------------------------------------------------------------
+# Explicit override wins, off-direction
+# ---------------------------------------------------------------------------
+statement ok con1
+SET pg_staleness_query_enabled=false
+
+statement ok con1
+ATTACH 'dbname=postgresscanner' AS wc4 (TYPE POSTGRES)
+
+statement ok con1
+DROP TABLE IF EXISTS wc4.public.staleness_gating_tbl4
+
+query I con1
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'wc4' AND table_name = 'staleness_gating_tbl4'
+----
+0
+
+statement ok con2
+ATTACH 'dbname=postgresscanner' AS wc4b (TYPE POSTGRES)
+
+statement ok con2
+CREATE TABLE wc4b.public.staleness_gating_tbl4 AS SELECT 1 AS x
+
+query I con1
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'wc4' AND table_name = 'staleness_gating_tbl4'
+----
+0
+
+statement ok con2
+DROP TABLE wc4b.public.staleness_gating_tbl4
+
+statement ok con2
+DETACH wc4b
+
+statement ok con1
+RESET pg_staleness_query_enabled
+
+statement ok con1
+DETACH wc4
+
+# ---------------------------------------------------------------------------
+# Custom query used in place of the default
+# ---------------------------------------------------------------------------
+statement ok con1
+SET pg_staleness_query='SELECT pg_class.oid, relname, pg_class.xmin FROM pg_class JOIN pg_namespace ON relnamespace = pg_namespace.oid WHERE relkind IN (''r'',''v'',''m'',''f'',''p'') AND pg_namespace.nspname = ${SCHEMA} ORDER BY pg_class.oid'
+
+statement ok con1
+ATTACH 'dbname=postgresscanner' AS wc5 (TYPE POSTGRES)
+
+statement ok con1
+DROP TABLE IF EXISTS wc5.public.staleness_gating_tbl5
+
+query I con1
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'wc5' AND table_name = 'staleness_gating_tbl5'
+----
+0
+
+statement ok con2
+ATTACH 'dbname=postgresscanner' AS wc5b (TYPE POSTGRES)
+
+statement ok con2
+CREATE TABLE wc5b.public.staleness_gating_tbl5 AS SELECT 1 AS x
+
+query I con1
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'wc5' AND table_name = 'staleness_gating_tbl5'
+----
+1
+
+statement ok con1
+DROP TABLE wc5.public.staleness_gating_tbl5
+
+statement ok con2
+DETACH wc5b
+
+statement ok con1
+RESET pg_staleness_query
+
+statement ok con1
+DETACH wc5
+
+# ---------------------------------------------------------------------------
+# Missing ${SCHEMA} placeholder is rejected before running
+# ---------------------------------------------------------------------------
+statement ok con1
+SET pg_staleness_query='SELECT pg_class.oid, relname, pg_class.xmin FROM pg_class ORDER BY pg_class.oid'
+
+statement ok con1
+ATTACH 'dbname=postgresscanner' AS wc6 (TYPE POSTGRES)
+
+statement error con1
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'wc6'
+----
+<REGEX>:.*pg_staleness_query must contain a \$\{SCHEMA\} placeholder.*
+
+statement ok con1
+RESET pg_staleness_query
+
+statement ok con1
+DETACH wc6
+
+# ---------------------------------------------------------------------------
+# Wrong column count is rejected, malformed query fails loud
+# ---------------------------------------------------------------------------
+statement ok con1
+SET pg_staleness_query='SELECT pg_class.oid FROM pg_class JOIN pg_namespace ON relnamespace = pg_namespace.oid WHERE pg_namespace.nspname = ${SCHEMA}'
+
+statement ok con1
+ATTACH 'dbname=postgresscanner' AS wc7 (TYPE POSTGRES)
+
+statement error con1
+SELECT count(*) FROM duckdb_tables() WHERE database_name = 'wc7'
+----
+<REGEX>:.*pg_staleness_query must return at least 3 columns.*
+
+statement ok con1
+RESET pg_staleness_query
+
+statement ok con1
+DETACH wc7

--- a/test/sql/storage/catalog_scan_concurrent_clear_stress.test_slow
+++ b/test/sql/storage/catalog_scan_concurrent_clear_stress.test_slow
@@ -6,6 +6,8 @@ require postgres_scanner
 
 require-env POSTGRES_TEST_DATABASE_AVAILABLE
 
+require-env SANITIZER_BUILD
+
 statement ok
 ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 

--- a/test/sql/storage/postgres_execute_transaction.test
+++ b/test/sql/storage/postgres_execute_transaction.test
@@ -57,7 +57,11 @@ statement ok
 DESCRIBE
 
 query I
-SELECT query FROM duckdb_logs_parsed('PostgresQueryLog');
+SELECT count(*) FROM duckdb_logs_parsed('PostgresQueryLog') WHERE query LIKE 'BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ%'
 ----
-BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ
-COMMIT
+1
+
+query I
+SELECT count(*) FROM duckdb_logs_parsed('PostgresQueryLog') WHERE query = 'COMMIT'
+----
+1


### PR DESCRIPTION
Resolves #512

## Problem

The Postgres catalog cache, `PostgresCatalogSet`, loads table/schema metadata once and holds it for the lifetime of the process (or until `pg_clear_cache()` is called). There's no automatic way to notice when the underlying Postgres tables actually changed. If another connection, or even the same connection on a later statement, does some DDL there's nothing to tell the cache its in-memory view is misaligned. The next query against that table uses the stale column/type info until the cache is eventually cleared from a separate action.

This isn't often an issue in everyday `duckdb-postgres` but it's _the_ contract that DuckLake depends on. DuckLake opens its own internal connection to the same attached Postgres database, a second `ClientContext`, not the user's, and expects catalog changes made through one path to become visible to the other without any manual cache management in-between. Right now that's not guaranteed. A `ClientContext` that primed its cache before another connection's DDL landed keeps serving the old shape indefinitely.

The cache should detect drift on its own by checking whether Postgres's own bookkeeping (`pg_class.xmin`, row identity) has moved since the last load, and only then pay the cost of reloading. That'll be correct without needing every caller to know when to invalidate.

## Fix

`PostgresTableSet` is the only nested set that can independently reload. `PostgresIndexSet` and `PostgresTypeSet` can not. They throw without a pre-supplied batch-load slice. So `PostgresTableSet` gets a staleness query: `(oid, relname, xmin)` per table in the schema, string-compared against the signature captured at last load. Any add, drop, rename changes that set. A plain row-count check doesn't.

```cpp
string PostgresTableSet::GetStalenessQuery() const {
        return "SELECT pg_class.oid, relname, pg_class.xmin FROM pg_class "
               "JOIN pg_namespace ON relnamespace = pg_namespace.oid "
               "WHERE relkind IN ('r','v','m','f','p') AND pg_namespace.nspname = $1 "
               "ORDER BY pg_class.oid";
}
```

The check runs once per `TryLoadEntries` call, inside the existing `load_lock`. It does not run per-entry, nor per-query. When there's a mismatch it clears and reloads exactly the way an explicit `pg_clear_cache()` already does.

A bug surfaced during implementation: 

A connection's own writes; i.e., `CREATE TABLE`, `DROP`, etc., were not updating the signature, so the *next* access on that same connection saw its own committed write as drift, wiped the entry it just created, and reloaded from Postgres. So it lost anything DuckDB's `AddColumn` path doesn't reconstruct, default values probably being the most notable. Fixed by refreshing the signature from `CreateTable`, `DropEntry`, and`ReloadEntry` directly, not from the generic bulk-load path.

That fix in turn exposed a second, narrower bug: 

A same-connection `ALTER TABLE` inside an explicit `BEGIN ... ROLLBACK`. Postgres reverts `xmin` on rollback (correct MVCC behavior) which can make a mid-transaction signature match the pre-transaction one once the rollback lands. The cache then keeps serving state that was never actually committed. Fixed by staging the signature instead of writing it directly whenever a transaction is open, and only promoting it to the real signature on `Commit()`. `Rollback()` just discards the pending value:

```cpp
void PostgresCatalogSet::RefreshStalenessSignature(PostgresTransaction &transaction) {
        auto signature = ComputeStalenessSignature(*transaction.Query(GetStalenessQuery()));
        if (transaction.GetTransactionState() == PostgresTransactionState::TRANSACTION_STARTED) {
                transaction.StageStalenessSignature(*this, std::move(signature));
                return;
        }
        staleness_signature = std::move(signature);
}
```

The pending value lives on `PostgresTransaction` as `pending_signatures`, mirroring the existing `referenced_entries` pattern, not on the catalog set itself since the cache is shared across every connection and a single pending slot would let one connection's commit or rollback clobber another's still-open transaction. `Commit()` promotes everything staged; `Rollback()` just drops it. Nothing in this path calls `ClearEntries()`, so it doesn't touch the reload machinery at all.

> [!NOTE]
> `PostgresIndexSet` and `PostgresTypeSet` don't get automatic staleness detection with this PR. They can't reload standalone at all today (confirmed: `LoadEntries` throws `InternalException` without a pre-supplied result slice; Same for both). Fixing that is a much bigger lift. Scope here is only `PostgresTableSet`

Verified against a live Postgres 16 instance, full `test/sql/storage/*` suite (108 tests, 3873 assertions) run twice, zero regressions. New coverage: external DDL visibility across two `ClientContext`s, an identity-swap case that rules out a pure cardinality signal, and a two-connection staged-signature case confirming one connection's pending (uncommitted) signature can't be promoted or clobbered by a concurrent, unrelated connection's commit.
