### PR TITLE
Apply the text protocol opt-out on the postgres_query (CONNECT) path

### DIFF
--- a/src/include/postgres_version.hpp
+++ b/src/include/postgres_version.hpp
@@ -14,6 +14,10 @@ namespace duckdb {
 
 enum class PostgresInstanceType { UNKNOWN, POSTGRES, AURORA, REDSHIFT };
 
+//! How scans decide between the binary COPY protocol and the text protocol.
+//! AUTO derives it from the server (the binary COPY protocol is not supported by Redshift).
+enum class PostgresTextProtocolMode { AUTO, TEXT, BINARY };
+
 struct PostgresVersion {
 	PostgresVersion() {
 	}

--- a/src/include/storage/postgres_catalog.hpp
+++ b/src/include/storage/postgres_catalog.hpp
@@ -27,12 +27,14 @@ class PostgresCatalog : public Catalog {
 public:
 	explicit PostgresCatalog(ClientContext &ctx, AttachedDatabase &db_p, string attach_path, AccessMode access_mode,
 	                         vector<string> schemas_to_load, PostgresIsolationLevel isolation_level,
-	                         const string &secret_name, SecretStorageTable secret_storage_table_p);
+	                         const string &secret_name, SecretStorageTable secret_storage_table_p,
+	                         PostgresTextProtocolMode text_protocol_mode);
 	~PostgresCatalog();
 
 	string attach_path;
 	AccessMode access_mode;
 	PostgresIsolationLevel isolation_level;
+	PostgresTextProtocolMode text_protocol_mode;
 
 public:
 	void Initialize(bool load_builtin) override;
@@ -70,6 +72,22 @@ public:
 
 	PostgresVersion GetPostgresVersion() const {
 		return version;
+	}
+
+	//! Resolve whether scans against this database must use the text protocol instead of the binary COPY
+	//! protocol. This is the single place where that decision is made for an attached database, so every
+	//! scan path (table scans, postgres_query/CONNECT, ...) agrees. `setting_value` is the value of the
+	//! `pg_use_text_protocol` setting, which acts as the default when the mode is AUTO.
+	bool UseTextProtocol(bool setting_value) const {
+		switch (text_protocol_mode) {
+		case PostgresTextProtocolMode::TEXT:
+			return true;
+		case PostgresTextProtocolMode::BINARY:
+			return false;
+		default:
+			// Redshift does not support the binary COPY protocol
+			return setting_value || version.type_v == PostgresInstanceType::REDSHIFT;
+		}
 	}
 
 	//! Label all postgres scans in the sub-tree as requiring materialization

--- a/src/postgres_query.cpp
+++ b/src/postgres_query.cpp
@@ -92,9 +92,9 @@ static unique_ptr<FunctionData> PGQueryBind(ClientContext &context, TableFunctio
 		result->types = return_types;
 		result->names = names;
 		result->read_only = false;
-		result->SetTablePages(0);
 		result->sql = std::move(sql);
 		result->use_transaction = use_transaction;
+		PostgresScanFunction::PrepareBind(pg_catalog.GetPostgresVersion(), context, *result, 0);
 		return std::move(result);
 	}
 	for (idx_t c = 0; c < nfields; c++) {
@@ -125,10 +125,10 @@ static unique_ptr<FunctionData> PGQueryBind(ClientContext &context, TableFunctio
 	result->types = return_types;
 	result->names = names;
 	result->read_only = false;
-	result->SetTablePages(0);
 	result->sql = std::move(sql);
 	result->params = PostgresParameters(std::move(param_types), std::move(param_values));
 	result->use_transaction = use_transaction;
+	PostgresScanFunction::PrepareBind(pg_catalog.GetPostgresVersion(), context, *result, 0);
 	return std::move(result);
 }
 

--- a/src/postgres_scanner.cpp
+++ b/src/postgres_scanner.cpp
@@ -110,6 +110,17 @@ static void PostgresGetSnapshot(ClientContext &context, PostgresVersion version,
 
 void PostgresScanFunction::PrepareBind(PostgresVersion version, ClientContext &context, PostgresBindData &bind_data,
                                        int64_t approx_num_pages) {
+	bind_data.version = version;
+	// resolve the protocol before any decision that depends on it (ctid scan, max threads)
+	// note that bind_data.use_text_protocol holds the value of the pg_use_text_protocol setting here
+	auto pg_catalog = bind_data.GetCatalog();
+	if (pg_catalog) {
+		// for an attached database the mode set at ATTACH time decides
+		bind_data.use_text_protocol = pg_catalog->UseTextProtocol(bind_data.use_text_protocol);
+	} else if (version.type_v == PostgresInstanceType::REDSHIFT) {
+		// no attached database (postgres_scan over a dsn) - Redshift does not support the binary COPY protocol
+		bind_data.use_text_protocol = true;
+	}
 	Value pages_per_task;
 	if (context.TryGetCurrentSetting("pg_pages_per_task", pages_per_task)) {
 		bind_data.pages_per_task = UBigIntValue::Get(pages_per_task);
@@ -140,10 +151,6 @@ void PostgresScanFunction::PrepareBind(PostgresVersion version, ClientContext &c
 		approx_num_pages = 0;
 	}
 	bind_data.SetTablePages(static_cast<idx_t>(approx_num_pages));
-	bind_data.version = version;
-	if (version.type_v == PostgresInstanceType::REDSHIFT) {
-		bind_data.use_text_protocol = true;
-	}
 }
 
 PostgresBindData::PostgresBindData(ClientContext &context) {

--- a/src/postgres_storage.cpp
+++ b/src/postgres_storage.cpp
@@ -47,6 +47,27 @@ static vector<string> ExtractSchemas(Value &value) {
 	}
 }
 
+static PostgresTextProtocolMode ExtractTextProtocolMode(Value &value) {
+	if (value.IsNull()) {
+		throw BinderException("Value for \"USE_TEXT_PROTOCOL\" option must not be null");
+	}
+	if (value.type().id() == LogicalTypeId::BOOLEAN) {
+		return BooleanValue::Get(value) ? PostgresTextProtocolMode::TEXT : PostgresTextProtocolMode::BINARY;
+	}
+	auto param = value.ToString();
+	auto lparam = StringUtil::Lower(param);
+	if (lparam == "auto") {
+		return PostgresTextProtocolMode::AUTO;
+	}
+	if (lparam == "true") {
+		return PostgresTextProtocolMode::TEXT;
+	}
+	if (lparam == "false") {
+		return PostgresTextProtocolMode::BINARY;
+	}
+	throw BinderException("Invalid value \"%s\" for use_text_protocol, expected TRUE, FALSE or AUTO", param);
+}
+
 static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> storage_info, ClientContext &context,
                                           AttachedDatabase &db, const string &name, AttachInfo &info,
                                           AttachOptions &attach_options) {
@@ -59,6 +80,7 @@ static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> sto
 	string secret_name;
 	vector<string> schemas_to_load;
 	PostgresIsolationLevel isolation_level = PostgresIsolationLevel::REPEATABLE_READ;
+	PostgresTextProtocolMode text_protocol_mode = PostgresTextProtocolMode::AUTO;
 	string secret_storage_table_name;
 	bool secret_storage_table_specified_explicitly = false;
 	for (auto &entry : attach_options.options) {
@@ -81,6 +103,8 @@ static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> sto
 				                      "REPEATABLE READ or SERIALIZABLE",
 				                      param);
 			}
+		} else if (lower_name == "use_text_protocol") {
+			text_protocol_mode = ExtractTextProtocolMode(entry.second);
 		} else if (lower_name == "secret_storage_table") {
 			secret_storage_table_name = entry.second.ToString();
 			secret_storage_table_specified_explicitly = true;
@@ -92,7 +116,7 @@ static unique_ptr<Catalog> PostgresAttach(optional_ptr<StorageExtensionInfo> sto
 	                                        secret_storage_table_specified_explicitly);
 	return make_uniq<PostgresCatalog>(context, db, std::move(attach_path), attach_options.access_mode,
 	                                  std::move(schemas_to_load), isolation_level, secret_name,
-	                                  std::move(secret_storage_table));
+	                                  std::move(secret_storage_table), text_protocol_mode);
 }
 
 static unique_ptr<TransactionManager> PostgresCreateTransactionManager(optional_ptr<StorageExtensionInfo> storage_info,

--- a/src/storage/postgres_catalog.cpp
+++ b/src/storage/postgres_catalog.cpp
@@ -70,9 +70,10 @@ unique_ptr<SecretEntry> GetSecret(ClientContext &context, const string &secret_n
 PostgresCatalog::PostgresCatalog(ClientContext &ctx, AttachedDatabase &db_p, string attach_path_p,
                                  AccessMode access_mode, vector<string> schemas_to_load,
                                  PostgresIsolationLevel isolation_level, const string &secret_name,
-                                 SecretStorageTable secret_storage_table_p)
+                                 SecretStorageTable secret_storage_table_p, PostgresTextProtocolMode text_protocol_mode)
     : Catalog(db_p), attach_path(std::move(attach_path_p)), access_mode(access_mode), isolation_level(isolation_level),
-      schemas(*this, schemas_to_load), connection_pool(make_shared_ptr<PostgresConnectionPool>(*this, ctx)),
+      text_protocol_mode(text_protocol_mode), schemas(*this, schemas_to_load),
+      connection_pool(make_shared_ptr<PostgresConnectionPool>(*this, ctx)),
       default_schema(schemas_to_load.size() > 0 ? schemas_to_load[0] : std::string()),
       secret_storage_table(std::move(secret_storage_table_p)) {
 	auto secret_entry = GetSecretEntry(ctx, secret_name);

--- a/test/sql/storage/attach_text_protocol.test
+++ b/test/sql/storage/attach_text_protocol.test
@@ -1,0 +1,110 @@
+# name: test/sql/storage/attach_text_protocol.test
+# description: Test the use_text_protocol option of ATTACH
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+DROP TABLE IF EXISTS s.text_protocol
+
+statement ok
+CREATE TABLE s.text_protocol(i INTEGER, s VARCHAR)
+
+statement ok
+INSERT INTO s.text_protocol VALUES (42, 'hello'), (NULL, NULL)
+
+statement ok
+DETACH s
+
+# the protocol is resolved at ATTACH time and applies to every scan of the database:
+# both regular table scans and postgres_query (which is what CONNECT runs)
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, USE_TEXT_PROTOCOL true)
+
+query II
+SELECT * FROM s.text_protocol ORDER BY i
+----
+42	hello
+NULL	NULL
+
+query II
+SELECT * FROM postgres_query('s', 'SELECT * FROM text_protocol ORDER BY i')
+----
+42	hello
+NULL	NULL
+
+statement ok
+DETACH s
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, USE_TEXT_PROTOCOL false)
+
+query II
+SELECT * FROM s.text_protocol ORDER BY i
+----
+42	hello
+NULL	NULL
+
+query II
+SELECT * FROM postgres_query('s', 'SELECT * FROM text_protocol ORDER BY i')
+----
+42	hello
+NULL	NULL
+
+statement ok
+DETACH s
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, USE_TEXT_PROTOCOL 'auto')
+
+query II
+SELECT * FROM s.text_protocol ORDER BY i
+----
+42	hello
+NULL	NULL
+
+query II
+SELECT * FROM postgres_query('s', 'SELECT * FROM text_protocol ORDER BY i')
+----
+42	hello
+NULL	NULL
+
+statement ok
+DETACH s
+
+# an explicit option at ATTACH time overrides the pg_use_text_protocol setting
+
+statement ok
+SET pg_use_text_protocol=true
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, USE_TEXT_PROTOCOL false)
+
+query II
+SELECT * FROM postgres_query('s', 'SELECT * FROM text_protocol ORDER BY i')
+----
+42	hello
+NULL	NULL
+
+statement ok
+DETACH s
+
+statement ok
+RESET pg_use_text_protocol
+
+statement error
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES, USE_TEXT_PROTOCOL 'maybe')
+----
+Invalid value "maybe" for use_text_protocol, expected TRUE, FALSE or AUTO
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+DROP TABLE IF EXISTS s.text_protocol


### PR DESCRIPTION
CONNECT on Redshift failed unless the user manually did SET pg_use_text_protocol=true, while ATTACH + USE worked.

DuckDB rewrites a CONNECT passthrough statement into postgres_query() (PostgresCatalog::RemoteExecute). Its bind, PGQueryBind, never called PostgresScanFunction::PrepareBind - which is where every server capability decision is made, including the Redshift opt-out from the binary COPY protocol. As a result the CONNECT path always wrapped the query in COPY (...) TO STDOUT (FORMAT "binary"), which Redshift does not support.

Instead of duplicating the Redshift check on each bind path, make the protocol a property of the attached database:
- add a use_text_protocol ATTACH option, accepting TRUE / FALSE / 'auto' (the default), stored on the PostgresCatalog
- PostgresCatalog::UseTextProtocol() is now the single place resolving the protocol for a database: an explicit option wins, 'auto' falls back to the pg_use_text_protocol setting or to Redshift auto-detection
- PGQueryBind calls PrepareBind, so the CONNECT path resolves it as well

Also resolve the protocol at the start of PrepareBind: it was set after the ctid scan and max_threads decisions that depend on it, which happened to be harmless only because Redshift reports major version 8.