### PR TITLE
CI extension load fix (1.5)

### DIFF
--- a/test/sql/misc/postgres_binary_read_basic.test
+++ b/test/sql/misc/postgres_binary_read_basic.test
@@ -5,7 +5,10 @@
 require postgres_scanner
 
 statement ok
-LOAD postgres_scanner;
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+DETACH s
 
 statement ok
 PRAGMA enable_verification

--- a/test/sql/misc/postgres_binary_read_complex.test
+++ b/test/sql/misc/postgres_binary_read_complex.test
@@ -5,7 +5,10 @@
 require postgres_scanner
 
 statement ok
-LOAD postgres_scanner;
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+DETACH s
 
 statement ok
 PRAGMA enable_verification

--- a/test/sql/misc/postgres_binary_read_copy_from.test
+++ b/test/sql/misc/postgres_binary_read_copy_from.test
@@ -5,7 +5,10 @@
 require postgres_scanner
 
 statement ok
-LOAD postgres_scanner;
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+DETACH s
 
 statement ok
 PRAGMA enable_verification

--- a/test/sql/misc/postgres_binary_read_errors.test
+++ b/test/sql/misc/postgres_binary_read_errors.test
@@ -5,7 +5,10 @@
 require postgres_scanner
 
 statement ok
-LOAD postgres_scanner;
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+DETACH s
 
 # --- Non-existent file ---
 statement error

--- a/test/sql/misc/postgres_binary_read_temporal.test
+++ b/test/sql/misc/postgres_binary_read_temporal.test
@@ -5,7 +5,10 @@
 require postgres_scanner
 
 statement ok
-LOAD postgres_scanner;
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+DETACH s
 
 statement ok
 PRAGMA enable_verification

--- a/test/sql/misc/postgres_hstore.test
+++ b/test/sql/misc/postgres_hstore.test
@@ -5,9 +5,6 @@
 require postgres_scanner
 
 statement ok
-LOAD postgres_scanner;
-
-statement ok
 PRAGMA enable_verification
 
 # --- postgres_hstore_get: basic lookups ---

--- a/test/sql/storage/attach_oauth_token.test
+++ b/test/sql/storage/attach_oauth_token.test
@@ -10,10 +10,6 @@ require-env PGOAUTHTOKEN
 
 require-env PG_OAUTH_DSN
 
-# Explicitly load the extension so settings are registered
-statement ok
-LOAD postgres_scanner;
-
 # Test 1: Connect using the pg_oauth_token DuckDB setting
 statement ok
 SET pg_oauth_token = '${PGOAUTHTOKEN}';


### PR DESCRIPTION
It was discovered that, due to the indetermined order of tests run by `unittest`, the `LOAD postgres` may run as a first access to the extension. `unittest` in 1.5 requires the exension to be autoloaded, in case of `LOAD postgres` it downloads the corresponding extension from the `core` repo. To prevent this, `LOAD postgres` is removed from tests.