### PR TITLE
Support insertion with plain INSERTs

### DIFF
--- a/src/include/storage/postgres_insert.hpp
+++ b/src/include/storage/postgres_insert.hpp
@@ -15,17 +15,18 @@
 #include "duckdb/planner/parsed_data/bound_create_table_info.hpp"
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/common/index_vector.hpp"
+#include "storage/postgres_catalog.hpp"
 
 namespace duckdb {
 
 class PostgresInsert : public PhysicalOperator {
 public:
 	//! INSERT INTO
-	PostgresInsert(PhysicalPlan &physical_plan, LogicalOperator &op, TableCatalogEntry &table,
-	               physical_index_vector_t<idx_t> column_index_map);
+	PostgresInsert(PhysicalPlan &physical_plan, PostgresCatalog &pg_catalog, ClientContext &context,
+	               LogicalOperator &op, TableCatalogEntry &table, physical_index_vector_t<idx_t> column_index_map);
 	//! CREATE TABLE AS
-	PostgresInsert(PhysicalPlan &physical_plan, LogicalOperator &op, SchemaCatalogEntry &schema,
-	               unique_ptr<BoundCreateTableInfo> info);
+	PostgresInsert(PhysicalPlan &physical_plan, PostgresCatalog &pg_catalog, ClientContext &context,
+	               LogicalOperator &op, SchemaCatalogEntry &schema, unique_ptr<BoundCreateTableInfo> info);
 
 	//! The table to insert into
 	optional_ptr<TableCatalogEntry> table;
@@ -37,6 +38,8 @@ public:
 	physical_index_vector_t<idx_t> column_index_map;
 	//! Whether or not we can keep the copy alive during Sink calls
 	bool keep_copy_alive = true;
+	//! Whether to use plain INSERTs instead of COPY
+	bool use_plain_inserts = false;
 
 public:
 	// Source interface
@@ -49,10 +52,30 @@ public:
 
 public:
 	// Sink interface
-	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
-	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
+	unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override {
+		if (use_plain_inserts) {
+			return GetGlobalSinkStatePlain(context);
+		} else {
+			return GetGlobalSinkStateCopy(context);
+		}
+	}
+
+	SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override {
+		if (use_plain_inserts) {
+			return SinkPlain(context, chunk, input);
+		} else {
+			return SinkCopy(context, chunk, input);
+		}
+	}
+
 	SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
-	                          OperatorSinkFinalizeInput &input) const override;
+	                          OperatorSinkFinalizeInput &input) const override {
+		if (use_plain_inserts) {
+			return FinalizePlain(pipeline, event, context, input);
+		} else {
+			return FinalizeCopy(pipeline, event, context, input);
+		}
+	}
 
 	bool IsSink() const override {
 		return true;
@@ -64,6 +87,17 @@ public:
 
 	string GetName() const override;
 	InsertionOrderPreservingMap<string> ParamsToString() const override;
+
+private:
+	static bool UsePlainInserts(PostgresCatalog &pg_catalog, ClientContext &context);
+	unique_ptr<GlobalSinkState> GetGlobalSinkStateCopy(ClientContext &context) const;
+	unique_ptr<GlobalSinkState> GetGlobalSinkStatePlain(ClientContext &context) const;
+	SinkResultType SinkCopy(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const;
+	SinkResultType SinkPlain(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const;
+	SinkFinalizeType FinalizeCopy(Pipeline &pipeline, Event &event, ClientContext &context,
+	                              OperatorSinkFinalizeInput &input) const;
+	SinkFinalizeType FinalizePlain(Pipeline &pipeline, Event &event, ClientContext &context,
+	                               OperatorSinkFinalizeInput &input) const;
 };
 
 } // namespace duckdb

--- a/src/storage/postgres_insert.cpp
+++ b/src/storage/postgres_insert.cpp
@@ -19,24 +19,25 @@
 
 namespace duckdb {
 
-PostgresInsert::PostgresInsert(PhysicalPlan &physical_plan, LogicalOperator &op, TableCatalogEntry &table,
+PostgresInsert::PostgresInsert(PhysicalPlan &physical_plan, PostgresCatalog &pg_catalog, ClientContext &context,
+                               LogicalOperator &op, TableCatalogEntry &table,
                                physical_index_vector_t<idx_t> column_index_map_p)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, op.types, 1), table(&table), schema(nullptr),
-      column_index_map(std::move(column_index_map_p)) {
+      column_index_map(std::move(column_index_map_p)), use_plain_inserts(UsePlainInserts(pg_catalog, context)) {
 }
 
-PostgresInsert::PostgresInsert(PhysicalPlan &physical_plan, LogicalOperator &op, SchemaCatalogEntry &schema,
-                               unique_ptr<BoundCreateTableInfo> info)
+PostgresInsert::PostgresInsert(PhysicalPlan &physical_plan, PostgresCatalog &pg_catalog, ClientContext &context,
+                               LogicalOperator &op, SchemaCatalogEntry &schema, unique_ptr<BoundCreateTableInfo> info)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, op.types, 1), table(nullptr), schema(&schema),
-      info(std::move(info)) {
+      info(std::move(info)), use_plain_inserts(UsePlainInserts(pg_catalog, context)) {
 }
 
 //===--------------------------------------------------------------------===//
 // States
 //===--------------------------------------------------------------------===//
-class PostgresInsertGlobalState : public GlobalSinkState {
+class PostgresInsertCopyGlobalState : public GlobalSinkState {
 public:
-	explicit PostgresInsertGlobalState(ClientContext &context, PostgresTableEntry &table, PostgresCopyFormat format)
+	explicit PostgresInsertCopyGlobalState(ClientContext &context, PostgresTableEntry &table, PostgresCopyFormat format)
 	    : table(table), insert_count(0), format(format) {
 	}
 
@@ -57,7 +58,22 @@ public:
 	}
 };
 
-vector<string> GetInsertColumns(const PostgresInsert &insert, PostgresTableEntry &entry) {
+class PostgresInsertPlainGlobalState : public GlobalSinkState {
+public:
+	explicit PostgresInsertPlainGlobalState(ClientContext &context, PostgresTableEntry &table,
+	                                        const vector<LogicalType> &varchar_types)
+	    : table(table), insert_count(0) {
+		varchar_chunk.Initialize(context, varchar_types);
+	}
+
+	PostgresTableEntry &table;
+	DataChunk varchar_chunk;
+	idx_t insert_count;
+	string base_insert_query;
+	string insert_values;
+};
+
+static vector<string> GetInsertColumns(const PostgresInsert &insert, PostgresTableEntry &entry) {
 	vector<string> column_names;
 	auto &columns = entry.GetColumns();
 	idx_t column_count;
@@ -83,7 +99,7 @@ vector<string> GetInsertColumns(const PostgresInsert &insert, PostgresTableEntry
 	return column_names;
 }
 
-unique_ptr<GlobalSinkState> PostgresInsert::GetGlobalSinkState(ClientContext &context) const {
+unique_ptr<GlobalSinkState> PostgresInsert::GetGlobalSinkStateCopy(ClientContext &context) const {
 	optional_ptr<PostgresTableEntry> insert_table;
 	if (!table) {
 		auto &schema_ref = *schema.get_mutable();
@@ -96,7 +112,7 @@ unique_ptr<GlobalSinkState> PostgresInsert::GetGlobalSinkState(ClientContext &co
 	auto &connection = transaction.GetConnection();
 	auto insert_columns = GetInsertColumns(*this, *insert_table);
 	auto format = insert_table->GetCopyFormat(context);
-	auto result = make_uniq<PostgresInsertGlobalState>(context, *insert_table, format);
+	auto result = make_uniq<PostgresInsertCopyGlobalState>(context, *insert_table, format);
 	auto &insert_column_names = result->insert_column_names;
 	if (!insert_columns.empty()) {
 		for (auto &str : insert_columns) {
@@ -112,11 +128,53 @@ unique_ptr<GlobalSinkState> PostgresInsert::GetGlobalSinkState(ClientContext &co
 	return std::move(result);
 }
 
+static string GetBaseInsertQuery(const PostgresTableEntry &table, const vector<string> &column_names) {
+	string query;
+	query += "INSERT INTO ";
+	query += PostgresUtils::WriteIdentifier(table.schema.name.GetIdentifierName());
+	query += ".";
+	query += PostgresUtils::WriteIdentifier(table.name.GetIdentifierName());
+	query += " ";
+	if (!column_names.empty()) {
+		query += "(";
+		for (idx_t c = 0; c < column_names.size(); c++) {
+			if (c > 0) {
+				query += ", ";
+			}
+			query += PostgresUtils::WriteIdentifier(column_names[c]);
+		}
+		query += ")";
+	}
+	query += " VALUES ";
+	return query;
+}
+
+unique_ptr<GlobalSinkState> PostgresInsert::GetGlobalSinkStatePlain(ClientContext &context) const {
+	PostgresTableEntry *insert_table;
+	if (!table) {
+		auto &schema_ref = *schema.get_mutable();
+		insert_table =
+		    &schema_ref.CreateTable(schema_ref.GetCatalogTransaction(context), *info)->Cast<PostgresTableEntry>();
+	} else {
+		insert_table = &table.get_mutable()->Cast<PostgresTableEntry>();
+	}
+	auto insert_columns = GetInsertColumns(*this, *insert_table);
+	vector<LogicalType> insert_types;
+	idx_t insert_column_count =
+	    insert_columns.empty() ? insert_table->GetColumns().LogicalColumnCount() : insert_columns.size();
+	for (idx_t c = 0; c < insert_column_count; c++) {
+		insert_types.push_back(LogicalType::VARCHAR);
+	}
+	auto result = make_uniq<PostgresInsertPlainGlobalState>(context, *insert_table, insert_types);
+	result->base_insert_query = GetBaseInsertQuery(*insert_table, insert_columns);
+	return std::move(result);
+}
+
 //===--------------------------------------------------------------------===//
 // Sink
 //===--------------------------------------------------------------------===//
-SinkResultType PostgresInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
-	auto &gstate = input.global_state.Cast<PostgresInsertGlobalState>();
+SinkResultType PostgresInsert::SinkCopy(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
+	auto &gstate = input.global_state.Cast<PostgresInsertCopyGlobalState>();
 	auto &transaction = PostgresTransaction::Get(context.client, gstate.table.catalog);
 	auto &connection = transaction.GetConnection();
 	if (!gstate.copy_is_active) {
@@ -135,12 +193,132 @@ SinkResultType PostgresInsert::Sink(ExecutionContext &context, DataChunk &chunk,
 	return SinkResultType::NEED_MORE_INPUT;
 }
 
+static void PostgresCastBlob(const Vector &input, Vector &result, idx_t count) {
+	static constexpr const char *HEX_TABLE = "0123456789ABCDEF";
+	auto input_data = FlatVector::GetData<string_t>(input);
+	auto result_data = FlatVector::GetDataMutable<string_t>(result);
+	for (idx_t r = 0; r < count; r++) {
+		if (FlatVector::IsNull(input, r)) {
+			FlatVector::SetNull(result, r, true);
+			continue;
+		}
+		auto blob_data = const_data_ptr_cast(input_data[r].GetData());
+		auto blob_size = input_data[r].GetSize();
+		if (blob_size == 0) {
+			result_data[r] = StringVector::AddString(result, "''");
+			continue;
+		}
+		string result_blob = "'\\x";
+		for (idx_t b = 0; b < blob_size; b++) {
+			auto blob_entry = blob_data[b];
+			auto byte_a = blob_entry >> 4;
+			auto byte_b = blob_entry & 0x0F;
+			result_blob += string(1, HEX_TABLE[byte_a]);
+			result_blob += string(1, HEX_TABLE[byte_b]);
+		}
+		result_blob += "'::BYTEA";
+		result_data[r] = StringVector::AddString(result, result_blob);
+	}
+}
+
+SinkResultType PostgresInsert::SinkPlain(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
+	static constexpr const idx_t INSERT_FLUSH_SIZE = 8000;
+
+	auto &gstate = input.global_state.Cast<PostgresInsertPlainGlobalState>();
+	auto &transaction = PostgresTransaction::Get(context.client, gstate.table.catalog);
+	auto &con = transaction.GetConnection();
+	// cast to varchar
+	D_ASSERT(chunk.ColumnCount() == gstate.varchar_chunk.ColumnCount());
+	chunk.Flatten();
+	gstate.varchar_chunk.Reset();
+	for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
+		switch (chunk.data[c].GetType().id()) {
+		case LogicalTypeId::BLOB:
+			PostgresCastBlob(chunk.data[c], gstate.varchar_chunk.data[c], chunk.size());
+			break;
+		case LogicalTypeId::TIMESTAMP_TZ: {
+			Vector timestamp_vector(LogicalType::TIMESTAMP);
+			timestamp_vector.Reinterpret(chunk.data[c]);
+			VectorOperations::Cast(context.client, timestamp_vector, gstate.varchar_chunk.data[c], chunk.size());
+			break;
+		}
+		default:
+			VectorOperations::Cast(context.client, chunk.data[c], gstate.varchar_chunk.data[c], chunk.size());
+			break;
+		}
+	}
+	gstate.varchar_chunk.SetChildCardinality(chunk.size());
+	// for each column type check if we need to add quotes or not
+	vector<bool> add_quotes;
+	for (idx_t c = 0; c < chunk.ColumnCount(); c++) {
+		bool add_quotes_for_type;
+		switch (chunk.data[c].GetType().id()) {
+		case LogicalTypeId::BOOLEAN:
+		case LogicalTypeId::TINYINT:
+		case LogicalTypeId::SMALLINT:
+		case LogicalTypeId::INTEGER:
+		case LogicalTypeId::BIGINT:
+		case LogicalTypeId::UTINYINT:
+		case LogicalTypeId::USMALLINT:
+		case LogicalTypeId::UINTEGER:
+		case LogicalTypeId::UBIGINT:
+		case LogicalTypeId::FLOAT:
+		case LogicalTypeId::DOUBLE:
+		case LogicalTypeId::BLOB:
+			add_quotes_for_type = false;
+			break;
+		case LogicalTypeId::ARRAY:
+		case LogicalTypeId::LIST:
+		case LogicalTypeId::STRUCT:
+			throw InvalidInputException("Insertion of '%s' columns is not supported with compatibility mode enabled "
+			                            "('pg_use_text_protocol' option)",
+			                            chunk.data[c].GetType().ToString());
+		default:
+			add_quotes_for_type = true;
+			break;
+		}
+		add_quotes.push_back(add_quotes_for_type);
+	}
+
+	// generate INSERT INTO statements
+	for (idx_t r = 0; r < chunk.size(); r++) {
+		if (!gstate.insert_values.empty()) {
+			gstate.insert_values += ", ";
+		}
+		gstate.insert_values += "(";
+		for (idx_t c = 0; c < gstate.varchar_chunk.ColumnCount(); c++) {
+			if (c > 0) {
+				gstate.insert_values += ", ";
+			}
+			if (FlatVector::IsNull(gstate.varchar_chunk.data[c], r)) {
+				gstate.insert_values += "NULL";
+			} else {
+				auto data = FlatVector::GetDataMutable<string_t>(gstate.varchar_chunk.data[c]);
+				if (add_quotes[c]) {
+					gstate.insert_values += PostgresUtils::WriteLiteral(data[r].GetString());
+				} else {
+					gstate.insert_values += data[r].GetString();
+				}
+			}
+		}
+		gstate.insert_values += ")";
+		if (gstate.insert_values.size() >= INSERT_FLUSH_SIZE) {
+			// perform the actual insert
+			con.Execute(context.client, gstate.base_insert_query + gstate.insert_values);
+			// reset the to-be-inserted values
+			gstate.insert_values = string();
+		}
+	}
+	gstate.insert_count += chunk.size();
+	return SinkResultType::NEED_MORE_INPUT;
+}
+
 //===--------------------------------------------------------------------===//
 // Finalize
 //===--------------------------------------------------------------------===//
-SinkFinalizeType PostgresInsert::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
-                                          OperatorSinkFinalizeInput &input) const {
-	auto &gstate = input.global_state.Cast<PostgresInsertGlobalState>();
+SinkFinalizeType PostgresInsert::FinalizeCopy(Pipeline &pipeline, Event &event, ClientContext &context,
+                                              OperatorSinkFinalizeInput &input) const {
+	auto &gstate = input.global_state.Cast<PostgresInsertCopyGlobalState>();
 	auto &transaction = PostgresTransaction::Get(context, gstate.table.catalog);
 	auto &connection = transaction.GetConnection();
 	gstate.FinishCopyTo(connection);
@@ -152,14 +330,33 @@ SinkFinalizeType PostgresInsert::Finalize(Pipeline &pipeline, Event &event, Clie
 	return SinkFinalizeType::READY;
 }
 
+SinkFinalizeType PostgresInsert::FinalizePlain(Pipeline &pipeline, Event &event, ClientContext &context,
+                                               OperatorSinkFinalizeInput &input) const {
+	auto &gstate = input.global_state.Cast<PostgresInsertPlainGlobalState>();
+	if (!gstate.insert_values.empty()) {
+		// perform the final insert
+		auto &transaction = PostgresTransaction::Get(context, gstate.table.catalog);
+		auto &con = transaction.GetConnection();
+		con.Execute(context, gstate.base_insert_query + gstate.insert_values);
+	}
+	return SinkFinalizeType::READY;
+}
+
 //===--------------------------------------------------------------------===//
 // GetData
 //===--------------------------------------------------------------------===//
 SourceResultType PostgresInsert::GetDataInternal(ExecutionContext &context, DataChunk &chunk,
                                                  OperatorSourceInput &input) const {
-	auto &insert_gstate = sink_state->Cast<PostgresInsertGlobalState>();
+	idx_t insert_count = 0;
+	if (use_plain_inserts) {
+		auto &insert_gstate = sink_state->Cast<PostgresInsertPlainGlobalState>();
+		insert_count = insert_gstate.insert_count;
+	} else {
+		auto &insert_gstate = sink_state->Cast<PostgresInsertCopyGlobalState>();
+		insert_count = insert_gstate.insert_count;
+	}
 	chunk.SetChildCardinality(1);
-	chunk.data[0].SetValue(0, Value::BIGINT(insert_gstate.insert_count));
+	chunk.data[0].SetValue(0, Value::BIGINT(insert_count));
 
 	return SourceResultType::FINISHED;
 }
@@ -175,6 +372,15 @@ InsertionOrderPreservingMap<string> PostgresInsert::ParamsToString() const {
 	InsertionOrderPreservingMap<string> result;
 	result["Table Name"] = table ? table->name.GetIdentifierName() : info->Base().GetTableName().GetIdentifierName();
 	return result;
+}
+
+bool PostgresInsert::UsePlainInserts(PostgresCatalog &pg_catalog, ClientContext &context) {
+	bool use_text_proto_user_option = false;
+	Value value;
+	if (context.TryGetCurrentSetting("pg_use_text_protocol", value) && !value.IsNull()) {
+		use_text_proto_user_option = BooleanValue::Get(value);
+	}
+	return pg_catalog.UseTextProtocol(use_text_proto_user_option);
 }
 
 //===--------------------------------------------------------------------===//
@@ -252,7 +458,7 @@ PhysicalOperator &PostgresCatalog::PlanInsert(ClientContext &context, PhysicalPl
 	MaterializePostgresScans(*plan);
 	auto &inner_plan = AddCastToPostgresTypes(context, planner, *plan);
 
-	auto &insert = planner.Make<PostgresInsert>(op, op.table, op.column_index_map);
+	auto &insert = planner.Make<PostgresInsert>(*this, context, op, op.table, op.column_index_map);
 	insert.children.push_back(inner_plan);
 	return insert;
 }
@@ -262,7 +468,7 @@ PhysicalOperator &PostgresCatalog::PlanCreateTableAs(ClientContext &context, Phy
 	auto &inner_plan = AddCastToPostgresTypes(context, planner, plan);
 	MaterializePostgresScans(inner_plan);
 
-	auto &insert = planner.Make<PostgresInsert>(op, op.schema, std::move(op.info));
+	auto &insert = planner.Make<PostgresInsert>(*this, context, op, op.schema, std::move(op.info));
 	insert.children.push_back(inner_plan);
 	return insert;
 }

--- a/test/sql/storage/attach_types_blob.test
+++ b/test/sql/storage/attach_types_blob.test
@@ -9,6 +9,11 @@ require-env POSTGRES_TEST_DATABASE_AVAILABLE
 statement ok
 ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 
+foreach plain FALSE TRUE
+
+statement ok
+SET pg_use_text_protocol = {plain}
+
 statement ok
 CREATE OR REPLACE TABLE s.blobs(b BLOB);
 
@@ -27,3 +32,8 @@ SELECT * FROM s.blobs
 \x00\x00\x00
 NULL
 thisisalongstring\x00\x00withnullbytes
+
+endloop
+
+statement ok
+RESET pg_use_text_protocol 

--- a/test/sql/storage/attach_types_char.test
+++ b/test/sql/storage/attach_types_char.test
@@ -22,6 +22,11 @@ hello	5
 (empty)	0
 NULL	NULL
 
+foreach plain FALSE TRUE
+
+statement ok
+SET pg_use_text_protocol = {plain}
+
 statement error
 INSERT INTO chars VALUES ('this string is too long')
 ----
@@ -38,6 +43,9 @@ INSERT INTO chars VALUES ('hello'), ('world'), ('maxlength1'), ('hello     '), (
 
 statement ok
 COMMIT
+
+statement ok
+SET pg_use_text_protocol = FALSE
 
 query II
 SELECT c, LENGTH(c) FROM chars
@@ -71,7 +79,15 @@ hello     	10
      	5
 NULL	NULL
 
+statement ok
+SET pg_use_text_protocol = {plain}
+
 statement error
 INSERT INTO varchars_fixed_len VALUES ('this string is too long')
 ----
 value too long
+
+endloop
+
+statement ok
+RESET pg_use_text_protocol 

--- a/test/sql/storage/attach_types_date.test
+++ b/test/sql/storage/attach_types_date.test
@@ -12,6 +12,11 @@ ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 statement ok
 USE s;
 
+foreach plain FALSE TRUE
+
+statement ok
+SET pg_use_text_protocol = {plain}
+
 statement ok
 CREATE OR REPLACE TABLE dates(d DATE);
 
@@ -58,6 +63,13 @@ statement error
 INSERT INTO dates VALUES (DATE '5881580-07-10');
 ----
 out of range
+
+endloop
+
+statement ok
+RESET pg_use_text_protocol 
+
+# TODO: BC with text proto
 
 query I
 SELECT * FROM dates

--- a/test/sql/storage/attach_types_decimal.test
+++ b/test/sql/storage/attach_types_decimal.test
@@ -12,6 +12,11 @@ ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 statement ok
 USE s;
 
+foreach plain FALSE TRUE
+
+statement ok
+SET pg_use_text_protocol = {plain}
+
 # no scale (integers)
 statement ok
 CREATE OR REPLACE TABLE decimals(d DECIMAL(4,0));
@@ -183,3 +188,8 @@ SELECT * FROM decimals
 1234567891234567891.1234567891234567891
 9999999999999999999.9999999999999999999
 -9999999999999999999.9999999999999999999
+
+endloop
+
+statement ok
+RESET pg_use_text_protocol 

--- a/test/sql/storage/attach_types_enum.test
+++ b/test/sql/storage/attach_types_enum.test
@@ -12,6 +12,11 @@ ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 statement ok
 USE s;
 
+foreach plain FALSE TRUE
+
+statement ok
+SET pg_use_text_protocol = {plain}
+
 statement ok
 DROP TABLE IF EXISTS enums
 
@@ -52,6 +57,11 @@ sad
 happy
 NULL
 
+endloop
+
+statement ok
+RESET pg_use_text_protocol 
+
 # reconnect
 statement ok
 ATTACH ':memory:' AS x
@@ -67,6 +77,11 @@ ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 
 statement ok
 USE s;
+
+foreach plain FALSE TRUE
+
+statement ok
+SET pg_use_text_protocol = {plain}
 
 query I
 SELECT UNNEST(enum_range(NULL::MOOD))
@@ -98,3 +113,8 @@ statement error
 CREATE OR REPLACE TABLE enums(e ENUM('sad', 'happy'));
 ----
 Enums in Postgres must be named
+
+endloop
+
+statement ok
+RESET pg_use_text_protocol 

--- a/test/sql/storage/attach_types_interval.test
+++ b/test/sql/storage/attach_types_interval.test
@@ -12,6 +12,11 @@ ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 statement ok
 USE s;
 
+foreach plain FALSE TRUE
+
+statement ok
+SET pg_use_text_protocol = {plain}
+
 statement ok
 CREATE OR REPLACE TABLE attach_intervals(i INTERVAL);
 
@@ -38,3 +43,8 @@ NULL
 00:30:15
 2 months 2 days 00:15:00
 -2 days
+
+endloop
+
+statement ok
+RESET pg_use_text_protocol 

--- a/test/sql/storage/attach_types_json.test
+++ b/test/sql/storage/attach_types_json.test
@@ -12,6 +12,11 @@ ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 statement ok
 USE s;
 
+foreach plain FALSE TRUE
+
+statement ok
+SET pg_use_text_protocol = {plain}
+
 query I
 SELECT * FROM pg_json
 ----
@@ -27,3 +32,8 @@ query I
 SELECT * FROM pg_json
 ----
 {"a": 42, "b": "string"}
+
+endloop
+
+statement ok
+RESET pg_use_text_protocol 

--- a/test/sql/storage/attach_types_macaddr.test
+++ b/test/sql/storage/attach_types_macaddr.test
@@ -12,6 +12,11 @@ ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 statement ok
 USE s;
 
+foreach plain FALSE TRUE
+
+statement ok
+SET pg_use_text_protocol = {plain}
+
 # macaddress only
 statement ok
 DELETE FROM pg_macaddr
@@ -27,6 +32,11 @@ SELECT * FROM pg_macaddr
 ----
 08:00:2b:01:02:03
 NULL
+
+endloop
+
+statement ok
+RESET pg_use_text_protocol 
 
 # complex types, including list of macaddr
 statement ok

--- a/test/sql/storage/attach_types_time.test
+++ b/test/sql/storage/attach_types_time.test
@@ -12,6 +12,11 @@ ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 statement ok
 USE s;
 
+foreach plain FALSE TRUE
+
+statement ok
+SET pg_use_text_protocol = {plain}
+
 statement ok
 CREATE OR REPLACE TABLE times(t TIME);
 
@@ -53,3 +58,8 @@ SELECT * FROM timestz
 NULL
 23:59:59+00
 23:59:59+06
+
+endloop
+
+statement ok
+RESET pg_use_text_protocol 

--- a/test/sql/storage/attach_types_timestamp.test
+++ b/test/sql/storage/attach_types_timestamp.test
@@ -12,6 +12,11 @@ ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 statement ok
 USE s;
 
+foreach plain FALSE TRUE
+
+statement ok
+SET pg_use_text_protocol = {plain}
+
 statement ok
 CREATE OR REPLACE TABLE timestamps(t TIMESTAMP);
 
@@ -49,6 +54,11 @@ insert into timestamps values (TIMESTAMP 'infinity');
 statement ok
 insert into timestamps values (TIMESTAMP '-infinity');
 
+# TODO: BC with text proto
+
+statement ok
+SET pg_use_text_protocol = FALSE
+
 query I
 SELECT * FROM timestamps
 ----
@@ -59,6 +69,9 @@ NULL
 294247-01-10 04:00:54.775806
 infinity
 -infinity
+
+statement ok
+SET pg_use_text_protocol = {plain}
 
 # timestamptz
 statement ok
@@ -137,3 +150,8 @@ SELECT * FROM timestamp_tbl
 2000-01-01 00:00:00
 NULL
 1980-01-01 23:59:59.123456
+
+endloop
+
+statement ok
+RESET pg_use_text_protocol 

--- a/test/sql/storage/attach_types_uuid.test
+++ b/test/sql/storage/attach_types_uuid.test
@@ -12,6 +12,11 @@ ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 statement ok
 USE s;
 
+foreach plain FALSE TRUE
+
+statement ok
+SET pg_use_text_protocol = {plain}
+
 statement ok
 CREATE OR REPLACE TABLE uuids(u UUID);
 
@@ -34,3 +39,8 @@ SELECT * FROM uuids
 NULL
 00000000-0000-0000-0000-000000000001
 ffffffff-ffff-ffff-ffff-ffffffffffff
+
+endloop
+
+statement ok
+RESET pg_use_text_protocol 

--- a/test/sql/storage/attach_types_varchar.test
+++ b/test/sql/storage/attach_types_varchar.test
@@ -12,6 +12,11 @@ ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 statement ok
 USE s;
 
+foreach plain FALSE TRUE
+
+statement ok
+SET pg_use_text_protocol = {plain}
+
 statement ok
 CREATE OR REPLACE TABLE varchars(v VARCHAR);
 
@@ -34,3 +39,8 @@ SELECT * FROM varchars
 this is a long string
 🦆🦆🦆🦆🦆🦆🦆🦆
 NULL
+
+endloop
+
+statement ok
+RESET pg_use_text_protocol 


### PR DESCRIPTION
The extension uses `COPY ... FROM STDIN (FORMAT BINARY)` when performing inserts into Postgres tables. This can cause problems with some Postgres-wire-compatible databases that do not support `COPY`.

This PR adds support for performing plain batch `INSERTs` instead of the `COPY`. Existing option `pg_use_text_protocol` is used to enable this behaviour.

Currently only basic column types are supported, support for composite types (`ARRAY`, `LIST`, `STRUCT`) may be added in future.

Testing: existing type tests are updated to also run with text protocol enabled.