### PR TITLE
Fix catalog staleness option

### DIFF
--- a/src/postgres_extension.cpp
+++ b/src/postgres_extension.cpp
@@ -222,13 +222,13 @@ static void LoadInternal(ExtensionLoader &loader) {
 	    "Whether or not the table catalog cache checks Postgres for external DDL changes before serving a "
 	    "cache hit. Defaults to the opposite of pg_use_information_schema_introspection when not explicitly set "
 	    "(off for pg protocol compatible databases that may not support the underlying query, on for Postgres).",
-	    LogicalType::BOOLEAN, Value(), PostgresClearCacheFunction::ClearCacheOnSetting);
+	    LogicalType::BOOLEAN, Value::BOOLEAN(false), PostgresClearCacheFunction::ClearCacheOnSetting, SetScope::GLOBAL);
 	config.AddExtensionOption(
 	    "pg_staleness_query",
 	    "Custom query used in place of the default table staleness query when pg_staleness_query_enabled "
 	    "resolves to true. Must contain a ${SCHEMA} placeholder and return at least 3 columns "
 	    "(identity, name, revision marker). Empty (default) uses the built-in pg_class/xmin query.",
-	    LogicalType::VARCHAR, Value(), PostgresClearCacheFunction::ClearCacheOnSetting);
+	    LogicalType::VARCHAR, Value(), PostgresClearCacheFunction::ClearCacheOnSetting, SetScope::GLOBAL);
 	config.AddExtensionOption("pg_statement_timeout_millis",
 	                          "Postgres statement timeout in milliseconds to set on scan connections",
 	                          LogicalType::UINTEGER, Value());

--- a/test/sql/storage/attach_connection_pool.test_slow
+++ b/test/sql/storage/attach_connection_pool.test_slow
@@ -120,12 +120,11 @@ s	SELECT 42
 statement ok
 DROP TABLE duckdb_connection_pool_test1
 
-# 2, not 1: DROP TABLE's cache-hit staleness check uses its own pooled connection
 query II
 SELECT catalog_name, available_connections
 FROM postgres_configure_pool(catalog_name='s')
 ----
-s	2
+s	1
 
 statement ok
 USE memory

--- a/test/sql/storage/catalog_cache_external_ddl_visibility.test
+++ b/test/sql/storage/catalog_cache_external_ddl_visibility.test
@@ -10,6 +10,9 @@ require-env POSTGRES_TEST_DATABASE_AVAILABLE
 statement ok con1
 ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 
+statement ok
+SET GLOBAL pg_staleness_query_enabled = TRUE
+
 statement ok con1
 USE s
 
@@ -50,3 +53,6 @@ USE memory
 
 statement ok con2
 DETACH s2
+
+statement ok
+RESET GLOBAL pg_staleness_query_enabled

--- a/test/sql/storage/catalog_cache_identity_swap_detected.test
+++ b/test/sql/storage/catalog_cache_identity_swap_detected.test
@@ -9,6 +9,9 @@ require-env POSTGRES_TEST_DATABASE_AVAILABLE
 statement ok con1
 ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 
+statement ok
+SET GLOBAL pg_staleness_query_enabled = TRUE
+
 statement ok con1
 USE s
 
@@ -56,3 +59,6 @@ USE memory
 
 statement ok con2
 DETACH s2
+
+statement ok
+RESET GLOBAL pg_staleness_query_enabled

--- a/test/sql/storage/catalog_cache_staged_signature_cross_connection.test
+++ b/test/sql/storage/catalog_cache_staged_signature_cross_connection.test
@@ -9,6 +9,9 @@ require-env POSTGRES_TEST_DATABASE_AVAILABLE
 statement ok con1
 ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
 
+statement ok
+SET GLOBAL pg_staleness_query_enabled = TRUE
+
 statement ok con1
 USE s
 
@@ -81,3 +84,6 @@ USE memory
 
 statement ok con2
 DETACH s2
+
+statement ok
+RESET GLOBAL pg_staleness_query_enabled

--- a/test/sql/storage/catalog_cache_staleness_wire_compat_gating.test
+++ b/test/sql/storage/catalog_cache_staleness_wire_compat_gating.test
@@ -12,6 +12,9 @@ require-env POSTGRES_TEST_DATABASE_AVAILABLE
 statement ok con1
 ATTACH 'dbname=postgresscanner' AS wc1 (TYPE POSTGRES)
 
+statement ok
+SET GLOBAL pg_staleness_query_enabled = TRUE
+
 statement ok con1
 DROP TABLE IF EXISTS wc1.public.staleness_gating_tbl1
 
@@ -43,6 +46,9 @@ DETACH wc1
 # ---------------------------------------------------------------------------
 # Default-off when compat mode is signaled
 # ---------------------------------------------------------------------------
+statement ok
+SET GLOBAL pg_staleness_query_enabled = NULL
+
 statement ok con1
 SET pg_use_information_schema_introspection=true
 
@@ -87,7 +93,7 @@ statement ok con1
 SET pg_use_information_schema_introspection=true
 
 statement ok con1
-SET pg_staleness_query_enabled=true
+SET GLOBAL pg_staleness_query_enabled=true
 
 statement ok con1
 ATTACH 'dbname=postgresscanner' AS wc3 (TYPE POSTGRES)
@@ -121,7 +127,7 @@ statement ok con1
 RESET pg_use_information_schema_introspection
 
 statement ok con1
-RESET pg_staleness_query_enabled
+RESET GLOBAL pg_staleness_query_enabled
 
 statement ok con1
 DETACH wc3
@@ -130,7 +136,7 @@ DETACH wc3
 # Explicit override wins, off-direction
 # ---------------------------------------------------------------------------
 statement ok con1
-SET pg_staleness_query_enabled=false
+SET GLOBAL pg_staleness_query_enabled=false
 
 statement ok con1
 ATTACH 'dbname=postgresscanner' AS wc4 (TYPE POSTGRES)
@@ -161,7 +167,7 @@ statement ok con2
 DETACH wc4b
 
 statement ok con1
-RESET pg_staleness_query_enabled
+RESET GLOBAL pg_staleness_query_enabled
 
 statement ok con1
 DETACH wc4
@@ -169,8 +175,11 @@ DETACH wc4
 # ---------------------------------------------------------------------------
 # Custom query used in place of the default
 # ---------------------------------------------------------------------------
+statement ok
+SET GLOBAL pg_staleness_query_enabled = TRUE
+
 statement ok con1
-SET pg_staleness_query='SELECT pg_class.oid, relname, pg_class.xmin FROM pg_class JOIN pg_namespace ON relnamespace = pg_namespace.oid WHERE relkind IN (''r'',''v'',''m'',''f'',''p'') AND pg_namespace.nspname = ${SCHEMA} ORDER BY pg_class.oid'
+SET GLOBAL pg_staleness_query='SELECT pg_class.oid, relname, pg_class.xmin FROM pg_class JOIN pg_namespace ON relnamespace = pg_namespace.oid WHERE relkind IN (''r'',''v'',''m'',''f'',''p'') AND pg_namespace.nspname = ${SCHEMA} ORDER BY pg_class.oid'
 
 statement ok con1
 ATTACH 'dbname=postgresscanner' AS wc5 (TYPE POSTGRES)
@@ -201,7 +210,7 @@ statement ok con2
 DETACH wc5b
 
 statement ok con1
-RESET pg_staleness_query
+RESET GLOBAL pg_staleness_query
 
 statement ok con1
 DETACH wc5
@@ -210,7 +219,7 @@ DETACH wc5
 # Missing ${SCHEMA} placeholder is rejected before running
 # ---------------------------------------------------------------------------
 statement ok con1
-SET pg_staleness_query='SELECT pg_class.oid, relname, pg_class.xmin FROM pg_class ORDER BY pg_class.oid'
+SET GLOBAL pg_staleness_query='SELECT pg_class.oid, relname, pg_class.xmin FROM pg_class ORDER BY pg_class.oid'
 
 statement ok con1
 ATTACH 'dbname=postgresscanner' AS wc6 (TYPE POSTGRES)
@@ -221,7 +230,7 @@ SELECT count(*) FROM duckdb_tables() WHERE database_name = 'wc6'
 <REGEX>:.*pg_staleness_query must contain a \$\{SCHEMA\} placeholder.*
 
 statement ok con1
-RESET pg_staleness_query
+RESET GLOBAL pg_staleness_query
 
 statement ok con1
 DETACH wc6
@@ -230,7 +239,7 @@ DETACH wc6
 # Wrong column count is rejected, malformed query fails loud
 # ---------------------------------------------------------------------------
 statement ok con1
-SET pg_staleness_query='SELECT pg_class.oid FROM pg_class JOIN pg_namespace ON relnamespace = pg_namespace.oid WHERE pg_namespace.nspname = ${SCHEMA}'
+SET GLOBAL pg_staleness_query='SELECT pg_class.oid FROM pg_class JOIN pg_namespace ON relnamespace = pg_namespace.oid WHERE pg_namespace.nspname = ${SCHEMA}'
 
 statement ok con1
 ATTACH 'dbname=postgresscanner' AS wc7 (TYPE POSTGRES)
@@ -241,7 +250,10 @@ SELECT count(*) FROM duckdb_tables() WHERE database_name = 'wc7'
 <REGEX>:.*pg_staleness_query must return at least 3 columns.*
 
 statement ok con1
-RESET pg_staleness_query
+RESET GLOBAL pg_staleness_query
 
 statement ok con1
 DETACH wc7
+
+statement ok
+RESET GLOBAL pg_staleness_query_enabled


### PR DESCRIPTION
This is a forward-port of PR #518.

This is a follow-up PR to #514:

 - it changes the default scope of `pg_staleness_query_enabled` and `pg_staleness_query options` to `GLOBAL` to be easily usable from DuckLake (where `SESSION` options are not propagated to Postgres)
 - it changes the default value of `pg_staleness_query_enabled` to not run the staleness query by default in non-DuckLake scenarios