### PR TITLE
Pin the first scan connection in multi-scan streaming queries

### DIFF
--- a/src/postgres_scanner.cpp
+++ b/src/postgres_scanner.cpp
@@ -451,6 +451,10 @@ bool PostgresGlobalState::TryOpenNewConnection(ClientContext &context, PostgresL
 					lstate.pool_connection = pg_catalog->GetConnectionPool().ForceGetConnection();
 				}
 				lstate.connection = PostgresConnection(lstate.pool_connection.GetConnection().GetConnection());
+				// unlike the main-thread connection this one is not in a transaction yet, so we pin it to
+				// the snapshot to prevent reads at its own instant
+				PostgresScanConnect(context, lstate.connection, snapshot, pg_catalog->access_mode,
+				                    pg_catalog->isolation_level);
 			}
 			used_main_thread = true;
 			return true;


### PR DESCRIPTION
Multiple scans of the same attached Postgres catalog in a single query hit the streaming path where the optimizer sets `can_use_main_thread = false`. On that path each scan reads over its own pool connections rather than the shared transaction connection.

In `PostgresGlobalState::TryOpenNewConnection`. The first connection a scan opens goes through the `ForceGetConnection()` branch, and that branch returned without ever calling `PostgresScanConnect`. Every later pool connection does call `PostgresScanConnect(..., snapshot, ...)`, so it runs `BEGIN` followed by `SET TRANSACTION SNAPSHOT` and reads at the shared snapshot. The first connection skipped both and scanned in autocommit, picking up a fresh snapshot on each `COPY`. So the first worker in a scan reads at a different point in time than the rest of the workers.