### PR TITLE
Pin the first scan connection (1.5)

### DIFF
--- a/src/postgres_scanner.cpp
+++ b/src/postgres_scanner.cpp
@@ -409,6 +409,10 @@ bool PostgresGlobalState::TryOpenNewConnection(ClientContext &context, PostgresL
 					lstate.pool_connection = pg_catalog->GetConnectionPool().ForceGetConnection();
 				}
 				lstate.connection = PostgresConnection(lstate.pool_connection.GetConnection().GetConnection());
+				// unlike the main-thread connection this one is not in a transaction yet, so we pin it to
+				// the snapshot to prevent reads at its own instant
+				PostgresScanConnect(context, lstate.connection, snapshot, pg_catalog->access_mode,
+				                    pg_catalog->isolation_level);
 			}
 			used_main_thread = true;
 			return true;


### PR DESCRIPTION
This is a backport of the PR #527 to `v1.5-variegata` stable branch.