### PR TITLE
Drain libpq results before throwing

### DIFF
--- a/src/postgres_connection.cpp
+++ b/src/postgres_connection.cpp
@@ -137,6 +137,7 @@ vector<unique_ptr<PostgresResult>> PostgresConnection::ExecuteQueries(ClientCont
 		throw std::runtime_error("Failed to execute query \"" + queries + "\": " + string(PQerrorMessage(GetConn())));
 	}
 	vector<unique_ptr<PostgresResult>> results;
+	string error_message;
 	while (true) {
 		auto res = PQgetResult(GetConn());
 		if (!res) {
@@ -144,13 +145,18 @@ vector<unique_ptr<PostgresResult>> PostgresConnection::ExecuteQueries(ClientCont
 		}
 		auto result = make_uniq<PostgresResult>(res);
 		if (ResultHasError(res)) {
-			throw std::runtime_error("Failed to execute query \"" + queries +
-			                         "\": " + string(PQresultErrorMessage(res)));
+			if (error_message.empty()) {
+				error_message = "Failed to execute query \"" + queries + "\": " + string(PQresultErrorMessage(res));
+			}
+			continue;
 		}
 		if (PQresultStatus(res) != PGRES_TUPLES_OK) {
 			continue;
 		}
 		results.push_back(std::move(result));
+	}
+	if (!error_message.empty()) {
+		throw std::runtime_error(error_message);
 	}
 	int64_t end_time = std::chrono::time_point_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now())
 	                       .time_since_epoch()


### PR DESCRIPTION

`PostgresConnection::ExecuteQueries` threw a `std::runtime_error` as soon as it saw a result with an error status, while still inside the `PQgetResult()` polling loop. This left the connection's result queue undrained — libpq expects every result to be pulled with `PQgetResult()` until it returns `NULL` before the connection is reused. Bailing out early via an exception left stale/pending results on the connection, so the next query issued on that (pooled/reused) connection could get confused by leftover state.


In `src/postgres_connection.cpp`, the error path no longer throws immediately. Instead, it records the first error message and `continue`s the loop so all remaining results are drained via `PQgetResult()`. Only after the loop exits (i.e. `PQgetResult()` returns `NULL`) is the preserved error thrown.
