### PR TITLE
Skip the COPY file header when scanning for row boundaries

### DIFF
--- a/src/include/postgres_binary_file_reader.hpp
+++ b/src/include/postgres_binary_file_reader.hpp
@@ -17,6 +17,9 @@ namespace duckdb {
 class PostgresBinaryFileReader {
 public:
 	static constexpr idx_t DEFAULT_BUFFER_SIZE = 32 * 1024 * 1024;
+	//! Size of the binary COPY file header: the signature, followed by the flags field and the header
+	//! extension area length (4 bytes each). Must match the header consumed by PostgresBinaryParser::CheckHeader.
+	static constexpr idx_t COPY_FILE_HEADER_SIZE = PostgresConversion::COPY_HEADER_LENGTH + 8;
 
 	PostgresBinaryFileReader(ClientContext &context, const string &file_path, vector<LogicalType> types,
 	                         vector<PostgresType> postgres_types, idx_t buffer_size = DEFAULT_BUFFER_SIZE);
@@ -38,6 +41,7 @@ private:
 	idx_t leftover;
 	idx_t leftover_offset;
 	bool finished;
+	bool header_scanned;
 };
 
 } // namespace duckdb

--- a/src/postgres_binary_file_reader.cpp
+++ b/src/postgres_binary_file_reader.cpp
@@ -16,7 +16,8 @@ PostgresBinaryFileReader::PostgresBinaryFileReader(ClientContext &context, const
                                                    vector<LogicalType> types_p, vector<PostgresType> postgres_types_p,
                                                    idx_t buffer_size_p)
     : column_ids(MakeSequentialColumnIds(types_p.size())), parser(std::move(types_p), std::move(postgres_types_p)),
-      buffer_size(buffer_size_p), file_offset(0), leftover(0), leftover_offset(0), finished(false) {
+      buffer_size(buffer_size_p), file_offset(0), leftover(0), leftover_offset(0), finished(false),
+      header_scanned(false) {
 	auto &fs = FileSystem::GetFileSystem(context);
 	file_handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
 	file_size = file_handle->GetFileSize();
@@ -67,15 +68,25 @@ bool PostgresBinaryFileReader::FillBuffer() {
 		return false;
 	}
 
-	idx_t valid = FindLastCompleteRow(read_buffer.get(), total);
-	if (valid == 0) {
-		if (file_offset >= file_size) {
-			valid = total;
-		} else {
-			throw IOException("Postgres binary file contains a row larger than the read buffer (%llu bytes). "
-			                  "Increase buffer_size.",
-			                  buffer_size);
-		}
+	// the first buffer starts with the COPY file header, which is not a tuple - skip it while scanning for
+	// row boundaries, but keep it in the buffer so that CheckHeader can still validate it
+	idx_t scan_offset = header_scanned ? 0 : MinValue(COPY_FILE_HEADER_SIZE, total);
+	header_scanned = true;
+
+	idx_t valid = FindLastCompleteRow(read_buffer.get() + scan_offset, total - scan_offset);
+	if (valid > 0) {
+		valid += scan_offset;
+	} else if (file_offset >= file_size) {
+		valid = total;
+	} else if (scan_offset > 0) {
+		// no complete row fits next to the header. The header is a boundary of its own, so hand the parser
+		// just the header and carry the partial row over to the next fill, where the whole buffer is
+		// available for it - a row only has to fit in buffer_size, not in buffer_size minus the header.
+		valid = scan_offset;
+	} else {
+		throw IOException("Postgres binary file contains a row larger than the read buffer (%llu bytes). "
+		                  "Increase buffer_size.",
+		                  buffer_size);
 	}
 
 	parser.SetBuffer(read_buffer.get(), valid);

--- a/src/postgres_binary_parser.cpp
+++ b/src/postgres_binary_parser.cpp
@@ -58,7 +58,9 @@ void PostgresBinaryParser::CheckHeader() {
 	if (!buffer_ptr) {
 		throw IOException("buffer_ptr not set in CheckHeader");
 	}
-	if (buffer_ptr + header_len >= end) {
+	// a buffer holding exactly the header is valid - the reader hands one over when the first row does
+	// not fit alongside it
+	if (buffer_ptr + header_len > end) {
 		throw IOException("Unable to read binary COPY data, invalid header");
 	}
 	if (memcmp(buffer_ptr, PostgresConversion::COPY_HEADER, magic_len) != 0) {

--- a/test/sql/misc/postgres_binary_read_buffer.test
+++ b/test/sql/misc/postgres_binary_read_buffer.test
@@ -1,0 +1,83 @@
+# name: test/sql/misc/postgres_binary_read_buffer.test
+# description: Test reading postgres binary files that span multiple read buffers
+# group: [misc]
+
+require postgres_scanner
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+DETACH s
+
+# Each row here is 10 bytes (2 byte field count + 4 byte length + 4 byte payload) and the file
+# header is 19 bytes, so these buffers hold only a handful of rows at a time.
+statement ok
+COPY (SELECT i::INTEGER AS a FROM range(1000) t(i)) TO '{TEST_DIR}/many_rows.bin' (FORMAT postgres_binary);
+
+query III
+SELECT count(*), min(a), max(a) FROM read_postgres_binary('{TEST_DIR}/many_rows.bin', columns={a: 'INTEGER'}, buffer_size=64);
+----
+1000	0	999
+
+query III
+SELECT count(*), min(a), max(a) FROM read_postgres_binary('{TEST_DIR}/many_rows.bin', columns={a: 'INTEGER'}, buffer_size=32);
+----
+1000	0	999
+
+# a buffer with no room for a row next to the header: the header is a boundary of its own, so the
+# first row is carried over to the next fill rather than rejected
+query III
+SELECT count(*), min(a), max(a) FROM read_postgres_binary('{TEST_DIR}/many_rows.bin', columns={a: 'INTEGER'}, buffer_size=24);
+----
+1000	0	999
+
+# a buffer of exactly the header size
+query III
+SELECT count(*), min(a), max(a) FROM read_postgres_binary('{TEST_DIR}/many_rows.bin', columns={a: 'INTEGER'}, buffer_size=19);
+----
+1000	0	999
+
+# the values must round-trip exactly, not just in aggregate
+query I
+SELECT count(*) FROM (
+    SELECT a FROM read_postgres_binary('{TEST_DIR}/many_rows.bin', columns={a: 'INTEGER'}, buffer_size=64)
+    EXCEPT
+    SELECT i::INTEGER FROM range(1000) t(i)
+);
+----
+0
+
+# variable width columns and NULLs across buffer boundaries
+statement ok
+COPY (SELECT i::INTEGER AS a, ('str_' || i)::VARCHAR AS b, CASE WHEN i % 3 = 0 THEN NULL ELSE i::BIGINT END AS c FROM range(500) t(i)) TO '{TEST_DIR}/mixed_rows.bin' (FORMAT postgres_binary);
+
+query IIII
+SELECT count(*), count(c), min(b), max(a) FROM read_postgres_binary('{TEST_DIR}/mixed_rows.bin', columns={a: 'INTEGER', b: 'VARCHAR', c: 'BIGINT'}, buffer_size=128);
+----
+500	333	str_0	499
+
+# rows of 56 bytes (2 byte field count + 4 byte length + 50 byte payload): larger than
+# buffer_size - 19 but no larger than buffer_size, so they only fit once the header is out of the way
+statement ok
+COPY (SELECT repeat('x', 50) AS a FROM range(20) t(i)) TO '{TEST_DIR}/wide_rows.bin' (FORMAT postgres_binary);
+
+query III
+SELECT count(*), min(length(a)), max(length(a)) FROM read_postgres_binary('{TEST_DIR}/wide_rows.bin', columns={a: 'VARCHAR'}, buffer_size=64);
+----
+20	50	50
+
+# the same rows in a buffer of exactly one row
+query III
+SELECT count(*), min(length(a)), max(length(a)) FROM read_postgres_binary('{TEST_DIR}/wide_rows.bin', columns={a: 'VARCHAR'}, buffer_size=56);
+----
+20	50	50
+
+# a row genuinely larger than the whole buffer is still rejected
+statement ok
+COPY (SELECT repeat('y', 100) AS a FROM range(5) t(i)) TO '{TEST_DIR}/huge_rows.bin' (FORMAT postgres_binary);
+
+statement error
+SELECT count(*) FROM read_postgres_binary('{TEST_DIR}/huge_rows.bin', columns={a: 'VARCHAR'}, buffer_size=64);
+----
+row larger than the read buffer


### PR DESCRIPTION
## Problem

`PostgresBinaryFileReader::FindLastCompleteRow` starts scanning at byte zero of the first buffer, so it reads the 19 byte binary COPY file header as if it were a tuple:

- `'P','G'` → field count `20551`
- `'C','O','P','Y'` → field length `1129270361`

That length exceeds any buffer, so no row is ever completed, the scan returns 0, and `FillBuffer` throws:

```
IO Error: Postgres binary file contains a row larger than the read buffer (N bytes). Increase buffer_size.
```

This fires for **any** file that does not fit in a single buffer. With the default `DEFAULT_BUFFER_SIZE` of 32 MiB, every postgres binary file larger than 32 MiB is rejected, no matter how small its rows are.

Files that fit in one buffer are unaffected, because `file_offset >= file_size` makes `FillBuffer` fall back to `valid = total` and the misparse is never observed. Every existing fixture in `test/sql/misc/postgres_binary_read_basic.test` is a few dozen bytes, which is why this was not caught.

## Fix

Two parts:

1. **Skip the header while scanning for row boundaries on the first fill**, keeping it in the buffer so `CheckHeader` still validates it. Subsequent fills start at a real row boundary and are unchanged.

2. **Treat the header itself as a valid first boundary.** The first fill only has `buffer_size - 19` bytes available after the header, so a first row larger than that but no larger than `buffer_size` would otherwise still be rejected even though it fits. When no complete row fits alongside the header, the parser is handed just the header and the partial row carries over to the next fill, where the whole buffer is available. `CheckHeader`'s bound goes from `>=` to `>` so a buffer holding exactly the header is accepted. A row therefore only has to fit in `buffer_size`, not in `buffer_size - 19`.

`COPY_FILE_HEADER_SIZE` is derived from `PostgresConversion::COPY_HEADER_LENGTH` so it stays in step with what `CheckHeader` consumes.

## Verification

`FindLastCompleteRow`, the patched `FillBuffer` loop and `CheckHeader` were reproduced verbatim in a standalone harness and driven with the exact byte streams `PostgresBinaryWriter` produces:

- 1000 rows × 10 bytes at buffer sizes 19, 20, 24, 28, 29, 32, 64 and 4096 — all read 1000 rows with correct payloads (`buffer_size=19` is a buffer of exactly the header)
- every row size from `buffer_size - 18` through `buffer_size`, for buffer sizes 32/40/48/56/64 — all succeed, covering the header-carry path
- rows of `buffer_size + 1` bytes — still rejected with `row larger than the read buffer`
- degenerate inputs: CSV data and a buffer smaller than the header still raise `invalid header`; header-only files read as zero rows

## Test

`test/sql/misc/postgres_binary_read_buffer.test`:

- 1000 row file at `buffer_size` 19, 24, 32 and 64, with an exact round trip via `EXCEPT`
- variable width columns and NULLs spanning buffer boundaries
- 56 byte rows read at `buffer_size=64` (larger than `bs - 19`, smaller than `bs`) and at `buffer_size=56` (exactly one row per buffer)
- 106 byte rows at `buffer_size=64`, which must still raise `row larger than the read buffer`

## Behaviour notes for review

- A file containing only the 19 byte header and no footer now reads as **zero rows** instead of raising `invalid header`. The parser already accepts files that end after N rows without a footer, so this matches existing leniency rather than adding new — but it is a change; say the word if footer validation is preferred.
- With `buffer_size` smaller than the header itself (< 19), the constructor still fails, but with `invalid header` rather than a message about the buffer being too small. The header is valid in that case — the buffer just cannot hold it. Pathological configuration; left as is to keep the change minimal.
- The pre-existing `valid = total` fallback at EOF (which tolerates trailing garbage in the last buffer) is preserved unchanged.
