### PR TITLE
Add a blob IN filter pushdown test (depends on database-connector#25)

### DIFF
--- a/test/sql/storage/filter_pushdown_blob_in.test
+++ b/test/sql/storage/filter_pushdown_blob_in.test
@@ -1,0 +1,61 @@
+# name: test/sql/storage/filter_pushdown_blob_in.test
+# description: Test pushing down IN filters over blob columns
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+SET pg_experimental_filter_pushdown=true
+
+statement ok
+CREATE OR REPLACE TABLE s.blob_in(id INTEGER, b BLOB);
+
+statement ok
+INSERT INTO s.blob_in VALUES (1, '\x01\x02'), (2, '\x03\x04'), (3, 'dpfkg'), (4, 'other'), (5, NULL);
+
+# blob constants in an IN list must be written as bytea literals, not bare hex digits
+query I
+SELECT id FROM s.blob_in WHERE b IN ('dpfkg'::BLOB, 'other'::BLOB) ORDER BY id
+----
+3
+4
+
+query I
+SELECT id FROM s.blob_in WHERE b IN ('\x01\x02'::BLOB, '\x03\x04'::BLOB) ORDER BY id
+----
+1
+2
+
+# a longer list, which the binder is more likely to keep as a COMPARE_IN expression
+query I
+SELECT id FROM s.blob_in WHERE b IN ('\x01\x02'::BLOB, '\x03\x04'::BLOB, 'dpfkg'::BLOB, 'other'::BLOB, '\xff'::BLOB, '\xfe'::BLOB) ORDER BY id
+----
+1
+2
+3
+4
+
+query I
+SELECT count(*) FROM s.blob_in WHERE b NOT IN ('dpfkg'::BLOB, 'other'::BLOB)
+----
+2
+
+# blobs containing quote and backslash bytes must survive the round trip
+statement ok
+INSERT INTO s.blob_in VALUES (6, '\x27\x5c');
+
+query I
+SELECT id FROM s.blob_in WHERE b IN ('\x27\x5c'::BLOB, '\x00'::BLOB) ORDER BY id
+----
+6
+
+statement ok
+DROP TABLE s.blob_in
+
+statement ok
+DETACH s


### PR DESCRIPTION
> **Blocked on https://github.com/duckdb/database-connector/pull/25 — CI will be red until that merges and the submodule pointer is bumped.**

## What this is

The SQL-level regression test for the blob `IN` pushdown bug. The fix itself is one line in the `database-connector` submodule (duckdb/database-connector#25); only the test belongs in this repo.

## The bug

`FilterPushdown::TransformExpression` serialises `COMPARE_IN` constants with `identifier_config`, whose blob literal prefix and suffix are empty, while `EncodeBlob` appends the closing quote unconditionally. With this repo's configuration (`'\x` prefix and `::BYTEA` suffix, set in `src/postgres_filter_pushdown.cpp:37`) a blob `IN` list is emitted as:

```sql
"blob_col" IN (6470666B67', 6F74686572')
```

Postgres rejects it with `trailing junk after numeric literal`, so `WHERE blob_col IN (...)` against an attached table fails outright. The `=` path was never affected — it already used `constant_config`.

## The test

`test/sql/storage/filter_pushdown_blob_in.test` runs blob `IN` / `NOT IN` filters against an attached Postgres table, including a six element list (the binder is more likely to keep a longer list as a `COMPARE_IN` rather than rewriting it to an `OR` chain) and blobs containing quote and backslash bytes. With the bug present these fail with the Postgres syntax error rather than returning wrong rows.

## To land

1. Merge duckdb/database-connector#25
2. Bump the `database-connector` submodule pointer on this branch
3. CI goes green, undraft
