### PR TITLE
Add a thread-local cache disable pool test (depends on database-connector#26)

### DIFF
--- a/test/sql/storage/attach_connection_pool_tl_cache_disable.test
+++ b/test/sql/storage/attach_connection_pool_tl_cache_disable.test
@@ -1,0 +1,66 @@
+# name: test/sql/storage/attach_connection_pool_tl_cache_disable.test
+# description: Test that disabling the thread-local cache hands parked connections back to the pool
+# group: [storage]
+
+require postgres_scanner
+
+require-env POSTGRES_TEST_DATABASE_AVAILABLE
+
+# the connection has to be parked and re-acquired on the same thread for this to be deterministic
+statement ok
+SET threads=1
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES);
+
+statement ok
+CREATE OR REPLACE TABLE s.pool_tl_cache(i INTEGER);
+
+statement ok
+INSERT INTO s.pool_tl_cache VALUES (1), (2), (3);
+
+statement ok
+SELECT catalog_name FROM postgres_configure_pool(catalog_name='s', enable_thread_local_cache=false, acquire_mode='wait', max_connections=1, wait_timeout_millis=5000)
+
+# control: with the cache off, a single connection is enough to run this query. If this fails the
+# rest of the test cannot distinguish a stranded connection from a query that needs two of them.
+query I
+SELECT count(*) FROM s.pool_tl_cache
+----
+3
+
+# park a connection in this thread's cache. The pool has to allow two connections for that to
+# happen at all - TryReturnToThreadLocal refuses to park while the pool is at capacity.
+statement ok
+SELECT catalog_name FROM postgres_configure_pool(catalog_name='s', enable_thread_local_cache=true, max_connections=2)
+
+query I
+SELECT count(*) FROM s.pool_tl_cache
+----
+3
+
+query I
+SELECT thread_local_cache_enabled FROM postgres_configure_pool(catalog_name='s')
+----
+true
+
+statement ok
+SELECT catalog_name FROM postgres_configure_pool(catalog_name='s', enable_thread_local_cache=false, max_connections=1)
+
+# the parked connection still counts against max_connections=1, so with the cache disabled this
+# query can only run if the connection was handed back to the pool instead of being stranded
+query I
+SELECT count(*) FROM s.pool_tl_cache
+----
+3
+
+query I
+SELECT thread_local_cache_enabled FROM postgres_configure_pool(catalog_name='s')
+----
+false
+
+statement ok
+DROP TABLE s.pool_tl_cache
+
+statement ok
+DETACH s


### PR DESCRIPTION
> **Blocked on https://github.com/duckdb/database-connector/pull/26 — CI will be red until that merges and the submodule pointer is bumped.**

## What this is

The SQL-level regression test for the thread-local connection cache leak. The fix itself is in the `database-connector` submodule (duckdb/database-connector#26); only the test belongs in this repo.

## The bug

`TryAcquireFromThreadLocal` stops consulting the cache as soon as `tl_cache_enabled` goes false, but a connection already parked in that thread's cache is left there. It still counts towards `total_connections` while being unreachable, so it permanently occupies a pool slot:

```
Connection pool timeout: all 1 connections in use, waited 100ms
```

Reachable from this repo through `postgres_configure_pool(enable_thread_local_cache := false)` on a pool that had the cache enabled and in use.

## The test

`test/sql/storage/attach_connection_pool_tl_cache_disable.test` walks enable → park → shrink → disable → query.

Two things worth flagging for review:

- It sets `threads=1`. The connection has to be parked and re-acquired on the same thread for the drain to fire, since the fix only recovers the calling thread's slot.
- It runs a **control query first** with the cache off and `max_connections=1`. If a single connection were not enough for this query, the later assertion could not distinguish a stranded connection from a query that simply needs two — the control makes that failure mode explicit rather than silent.

The pool also has a `test/test_pool.cpp` unit test in the connector PR, which is the more direct regression. Note that `database-connector/test` is not wired into this repo's CI, so that one only runs in the connector repo.

## To land

1. Merge duckdb/database-connector#26
2. Bump the `database-connector` submodule pointer on this branch
3. CI goes green, undraft
