### PR TITLE
Skip the COPY header when scanning for row (1.5)

### DIFF
--- a/src/include/postgres_binary_file_reader.hpp
+++ b/src/include/postgres_binary_file_reader.hpp
@@ -16,6 +16,9 @@ namespace duckdb {
 class PostgresBinaryFileReader {
 public:
 	static constexpr idx_t DEFAULT_BUFFER_SIZE = 32 * 1024 * 1024;
+	//! Size of the binary COPY file header: the signature, followed by the flags field and the header
+	//! extension area length (4 bytes each). Must match the header consumed by PostgresBinaryParser::CheckHeader.
+	static constexpr idx_t COPY_FILE_HEADER_SIZE = PostgresConversion::COPY_HEADER_LENGTH + 8;
 
 	PostgresBinaryFileReader(ClientContext &context, const string &file_path, vector<LogicalType> types,
 	                         vector<PostgresType> postgres_types, idx_t buffer_size = DEFAULT_BUFFER_SIZE);
@@ -37,6 +40,7 @@ private:
 	idx_t leftover;
 	idx_t leftover_offset;
 	bool finished;
+	bool header_scanned;
 };
 
 } // namespace duckdb

--- a/src/postgres_binary_file_reader.cpp
+++ b/src/postgres_binary_file_reader.cpp
@@ -14,7 +14,8 @@ PostgresBinaryFileReader::PostgresBinaryFileReader(ClientContext &context, const
                                                    vector<LogicalType> types_p, vector<PostgresType> postgres_types_p,
                                                    idx_t buffer_size_p)
     : column_ids(MakeSequentialColumnIds(types_p.size())), parser(std::move(types_p), std::move(postgres_types_p)),
-      buffer_size(buffer_size_p), file_offset(0), leftover(0), leftover_offset(0), finished(false) {
+      buffer_size(buffer_size_p), file_offset(0), leftover(0), leftover_offset(0), finished(false),
+      header_scanned(false) {
 	auto &fs = FileSystem::GetFileSystem(context);
 	file_handle = fs.OpenFile(file_path, FileFlags::FILE_FLAGS_READ);
 	file_size = file_handle->GetFileSize();
@@ -65,15 +66,25 @@ bool PostgresBinaryFileReader::FillBuffer() {
 		return false;
 	}
 
-	idx_t valid = FindLastCompleteRow(read_buffer.get(), total);
-	if (valid == 0) {
-		if (file_offset >= file_size) {
-			valid = total;
-		} else {
-			throw IOException("Postgres binary file contains a row larger than the read buffer (%llu bytes). "
-			                  "Increase buffer_size.",
-			                  buffer_size);
-		}
+	// the first buffer starts with the COPY file header, which is not a tuple - skip it while scanning for
+	// row boundaries, but keep it in the buffer so that CheckHeader can still validate it
+	idx_t scan_offset = header_scanned ? 0 : MinValue(COPY_FILE_HEADER_SIZE, total);
+	header_scanned = true;
+
+	idx_t valid = FindLastCompleteRow(read_buffer.get() + scan_offset, total - scan_offset);
+	if (valid > 0) {
+		valid += scan_offset;
+	} else if (file_offset >= file_size) {
+		valid = total;
+	} else if (scan_offset > 0) {
+		// no complete row fits next to the header. The header is a boundary of its own, so hand the parser
+		// just the header and carry the partial row over to the next fill, where the whole buffer is
+		// available for it - a row only has to fit in buffer_size, not in buffer_size minus the header.
+		valid = scan_offset;
+	} else {
+		throw IOException("Postgres binary file contains a row larger than the read buffer (%llu bytes). "
+		                  "Increase buffer_size.",
+		                  buffer_size);
 	}
 
 	parser.SetBuffer(read_buffer.get(), valid);

--- a/src/postgres_binary_parser.cpp
+++ b/src/postgres_binary_parser.cpp
@@ -54,7 +54,9 @@ void PostgresBinaryParser::CheckHeader() {
 	if (!buffer_ptr) {
 		throw IOException("buffer_ptr not set in CheckHeader");
 	}
-	if (buffer_ptr + header_len >= end) {
+	// a buffer holding exactly the header is valid - the reader hands one over when the first row does
+	// not fit alongside it
+	if (buffer_ptr + header_len > end) {
 		throw IOException("Unable to read binary COPY data, invalid header");
 	}
 	if (memcmp(buffer_ptr, PostgresConversion::COPY_HEADER, magic_len) != 0) {

--- a/test/sql/misc/postgres_binary_read_buffer.test
+++ b/test/sql/misc/postgres_binary_read_buffer.test
@@ -1,0 +1,83 @@
+# name: test/sql/misc/postgres_binary_read_buffer.test
+# description: Test reading postgres binary files that span multiple read buffers
+# group: [misc]
+
+require postgres_scanner
+
+statement ok
+ATTACH 'dbname=postgresscanner' AS s (TYPE POSTGRES)
+
+statement ok
+DETACH s
+
+# Each row here is 10 bytes (2 byte field count + 4 byte length + 4 byte payload) and the file
+# header is 19 bytes, so these buffers hold only a handful of rows at a time.
+statement ok
+COPY (SELECT i::INTEGER AS a FROM range(1000) t(i)) TO '{TEST_DIR}/many_rows.bin' (FORMAT postgres_binary);
+
+query III
+SELECT count(*), min(a), max(a) FROM read_postgres_binary('{TEST_DIR}/many_rows.bin', columns={a: 'INTEGER'}, buffer_size=64);
+----
+1000	0	999
+
+query III
+SELECT count(*), min(a), max(a) FROM read_postgres_binary('{TEST_DIR}/many_rows.bin', columns={a: 'INTEGER'}, buffer_size=32);
+----
+1000	0	999
+
+# a buffer with no room for a row next to the header: the header is a boundary of its own, so the
+# first row is carried over to the next fill rather than rejected
+query III
+SELECT count(*), min(a), max(a) FROM read_postgres_binary('{TEST_DIR}/many_rows.bin', columns={a: 'INTEGER'}, buffer_size=24);
+----
+1000	0	999
+
+# a buffer of exactly the header size
+query III
+SELECT count(*), min(a), max(a) FROM read_postgres_binary('{TEST_DIR}/many_rows.bin', columns={a: 'INTEGER'}, buffer_size=19);
+----
+1000	0	999
+
+# the values must round-trip exactly, not just in aggregate
+query I
+SELECT count(*) FROM (
+    SELECT a FROM read_postgres_binary('{TEST_DIR}/many_rows.bin', columns={a: 'INTEGER'}, buffer_size=64)
+    EXCEPT
+    SELECT i::INTEGER FROM range(1000) t(i)
+);
+----
+0
+
+# variable width columns and NULLs across buffer boundaries
+statement ok
+COPY (SELECT i::INTEGER AS a, ('str_' || i)::VARCHAR AS b, CASE WHEN i % 3 = 0 THEN NULL ELSE i::BIGINT END AS c FROM range(500) t(i)) TO '{TEST_DIR}/mixed_rows.bin' (FORMAT postgres_binary);
+
+query IIII
+SELECT count(*), count(c), min(b), max(a) FROM read_postgres_binary('{TEST_DIR}/mixed_rows.bin', columns={a: 'INTEGER', b: 'VARCHAR', c: 'BIGINT'}, buffer_size=128);
+----
+500	333	str_0	499
+
+# rows of 56 bytes (2 byte field count + 4 byte length + 50 byte payload): larger than
+# buffer_size - 19 but no larger than buffer_size, so they only fit once the header is out of the way
+statement ok
+COPY (SELECT repeat('x', 50) AS a FROM range(20) t(i)) TO '{TEST_DIR}/wide_rows.bin' (FORMAT postgres_binary);
+
+query III
+SELECT count(*), min(length(a)), max(length(a)) FROM read_postgres_binary('{TEST_DIR}/wide_rows.bin', columns={a: 'VARCHAR'}, buffer_size=64);
+----
+20	50	50
+
+# the same rows in a buffer of exactly one row
+query III
+SELECT count(*), min(length(a)), max(length(a)) FROM read_postgres_binary('{TEST_DIR}/wide_rows.bin', columns={a: 'VARCHAR'}, buffer_size=56);
+----
+20	50	50
+
+# a row genuinely larger than the whole buffer is still rejected
+statement ok
+COPY (SELECT repeat('y', 100) AS a FROM range(5) t(i)) TO '{TEST_DIR}/huge_rows.bin' (FORMAT postgres_binary);
+
+statement error
+SELECT count(*) FROM read_postgres_binary('{TEST_DIR}/huge_rows.bin', columns={a: 'VARCHAR'}, buffer_size=64);
+----
+row larger than the read buffer


### PR DESCRIPTION
This is a backport of the PR #532 to `v1.5-variegata` stable branch.

PostgresBinaryFileReader::FindLastCompleteRow started scanning at byte zero of the first buffer, so it read the 19 byte binary COPY file header as if it were a tuple: 'PG' became a field count of 20551 and 'COPY' became a field length of 1129270361. No row could ever be completed, the scan returned 0, and the reader threw

  Postgres binary file contains a row larger than the read buffer

for any file that did not fit in a single buffer. With the default 32MB buffer that rejected every postgres binary file larger than 32MB, regardless of how small its rows were.

Skip the header while scanning for row boundaries on the first fill, but keep it in the buffer so CheckHeader can still validate it.

When no complete row fits alongside the header, hand the parser just the header and carry the partial row over to the next fill, where the whole buffer is available for it. Otherwise a row larger than buffer_size - 19 but no larger than buffer_size would still be rejected even though it fits. CheckHeader's bound becomes '>' so that a buffer holding exactly the header is accepted.

Files that fit in one buffer were unaffected, which is why the existing tests - all of which use tiny fixtures - did not catch this.